### PR TITLE
Handle short PCM windows in mixer

### DIFF
--- a/lib/modules/editing/multitrack_editor.dart
+++ b/lib/modules/editing/multitrack_editor.dart
@@ -13,6 +13,7 @@ import 'package:audio_waveforms/audio_waveforms.dart';
 4    單軌管理                            各軌可個別刪除 / 播放*/
 /// Spectrum 條狀圖 Widget
 import 'dart:async';
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:audio_waveforms/audio_waveforms.dart';
@@ -109,13 +110,13 @@ class _MultiTrackEditorState extends State<MultiTrackEditor> {
         final pcm = _pcmData[track.filePath];
         final player = _players[track.filePath];
         if (pcm == null || player == null) continue;
+        if (pcm.length < windowSize) continue;
 
         final posMs = player.position.inMilliseconds;
         final center = (posMs / 1000 * sampleRate).toInt();
-        final start = (center - windowSize ~/ 2).clamp(
-          0,
-          pcm.length - windowSize,
-        );
+        final rawStart = center - windowSize ~/ 2;
+        final maxStart = pcm.length - windowSize;
+        final start = math.max(0, math.min(rawStart, maxStart)).toInt();
         final window = pcm.sublist(start, start + windowSize);
 
         for (int i = 0; i < window.length; i++) {


### PR DESCRIPTION
## Summary
- prevent sublist errors by skipping tracks with insufficient PCM samples
- clamp FFT window start within PCM bounds using `math.max`/`math.min`

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ec7a5fef48328b7d2e9b43d95bdef