### PR TITLE
Add FFmpeg integration for Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # clipnote_audio
 
 A new Flutter project.
+
+## FFmpeg configuration
+
+This project bundles FFmpeg for both Android and iOS.
+
+### Android
+1. Place the FFmpeg shared libraries at `android/ffmpeg-build/<abi>/libffmpeg.so` for
+   each supported ABI (`arm64-v8a` and `armeabi-v7a`). Placeholder files are
+   provided for development.
+2. During the Gradle `preBuild` phase, these libraries are copied into
+   `android/app/src/main/jniLibs/<abi>` so they are packaged with the APK.
+3. Build the app:
+
+   ```sh
+   flutter build apk
+   ```
+
+### iOS
+1. The `ios/Podfile` includes the `ffmpeg-kit-ios-full` pod which provides
+   `FFmpegKit.xcframework`.
+2. Install the pods:
+
+   ```sh
+   cd ios
+   pod install
+   ```
+3. Open `Runner.xcworkspace` in Xcode and build the project.
+
+These steps ensure that both platforms link against FFmpeg.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,3 +42,20 @@ android {
 flutter {
     source = "../.."
 }
+
+// Copy prebuilt FFmpeg shared libraries into the app's jniLibs
+val jniLibsDir = File(projectDir, "src/main/jniLibs")
+
+tasks.register<Copy>("copyFfmpegArm64") {
+    from(File(rootDir, "ffmpeg-build/arm64-v8a/libffmpeg.so"))
+    into(File(jniLibsDir, "arm64-v8a"))
+}
+
+tasks.register<Copy>("copyFfmpegArmv7") {
+    from(File(rootDir, "ffmpeg-build/armeabi-v7a/libffmpeg.so"))
+    into(File(jniLibsDir, "armeabi-v7a"))
+}
+
+tasks.named("preBuild") {
+    dependsOn("copyFfmpegArm64", "copyFfmpegArmv7")
+}

--- a/android/ffmpeg-build/arm64-v8a/libffmpeg.so
+++ b/android/ffmpeg-build/arm64-v8a/libffmpeg.so
@@ -1,0 +1,1 @@
+stub arm64 libffmpeg.so

--- a/android/ffmpeg-build/armeabi-v7a/libffmpeg.so
+++ b/android/ffmpeg-build/armeabi-v7a/libffmpeg.so
@@ -1,0 +1,1 @@
+stub armeabi libffmpeg.so

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,22 @@
+platform :ios, '12.0'
+
+# Prevent Cocoapods from sending stats
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+require File.expand_path(File.join('..', '..', 'flutter', 'packages', 'flutter_tools', 'bin', 'podhelper'), __FILE__)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # Include FFmpegKit xcframework
+  pod 'ffmpeg-kit-ios-full', '~> 6.0'
+end
+
+post_install do |installer|
+  flutter_additional_ios_build_settings(installer)
+end


### PR DESCRIPTION
## Summary
- copy FFmpeg shared libraries into Android jniLibs via Gradle
- integrate FFmpegKit through a CocoaPods Podfile for iOS
- document FFmpeg configuration for both platforms

## Testing
- `flutter test` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*
- `flutter build ios --no-codesign` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68919badc6ac8328a2b60e4211d9cf4c