### PR TITLE
docs: add bilingual README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-# clipnote_audio
+# Clipnote Audio
 
-A new Flutter project.
+Clipnote Audio is a Flutter-based multi-track audio editor that allows you to mix, analyze, and visualize audio in real time.
+
+Clipnote Audio 是一款基於 Flutter 的多軌音訊編輯器，可用於即時混音、分析與視覺化音訊。
+
+## Features / 功能
+
+- Unified playback control for all tracks / 所有音軌一鍵播放與暫停
+- PCM mixing across tracks / 各音軌的 PCM 混音
+- Real-time FFT analysis (200 ms interval) / 即時 FFT（每 200 毫秒分析一次）
+- 500 Hz spectrum visualization / 500 Hz 頻段的視覺化頻譜
+- Per-track management (delete or play individually) / 單軌管理（刪除與播放控制）
+- Reverb and volume adjustment modules / 混響與音量調整模組
+- File uploader for adding audio files / 檔案上傳器，可新增音訊檔
+- Merge & mix utilities for output / 合併與混音工具，可輸出音訊
+
+## Usage / 使用方式
+
+1. Install Flutter and its dependencies.
+2. Run `flutter pub get` to install packages.
+3. Run `flutter run` to launch the application.
+4. Use the **新增音軌** button to add tracks and explore mixing and visualization.
+


### PR DESCRIPTION
## Summary
- replace placeholder README with bilingual introduction and feature list
- outline basic usage instructions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a295c09c83288875f603ef41bc17