### PR TITLE
Replace just_audio with FFmpeg FFI decoder

### DIFF
--- a/lib/modules/decoding/ffmpeg_decoder.dart
+++ b/lib/modules/decoding/ffmpeg_decoder.dart
@@ -1,0 +1,53 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart';
+
+/// Holds decoded PCM data along with metadata like sample rate.
+class PcmData {
+  final Uint8List buffer;
+  final int sampleRate;
+  PcmData(this.buffer, this.sampleRate);
+}
+
+/// Simple FFmpeg decoder wrapper using `dart:ffi`.
+class FFmpegDecoder {
+  final DynamicLibrary _lib;
+  late final _Decode _decode;
+  late final _Free _free;
+
+  FFmpegDecoder({DynamicLibrary? library})
+      : _lib = library ?? DynamicLibrary.open('libffmpeg.so') {
+    _decode =
+        _lib.lookupFunction<_DecodeNative, _Decode>('decode_audio');
+    _free = _lib.lookupFunction<_FreeNative, _Free>('free_buffer');
+  }
+
+  /// Decode [filePath] into a PCM buffer. The native function returns a
+  /// pointer to the PCM data along with its length and sample rate.
+  PcmData decode(String filePath) {
+    final pathPtr = filePath.toNativeUtf8();
+    final lengthPtr = calloc<Int32>();
+    final sampleRatePtr = calloc<Int32>();
+
+    final dataPtr = _decode(pathPtr, lengthPtr, sampleRatePtr);
+    final length = lengthPtr.value;
+    final sampleRate = sampleRatePtr.value;
+
+    final buffer = Uint8List.fromList(dataPtr.asTypedList(length));
+
+    _free(dataPtr);
+    calloc.free(pathPtr);
+    calloc.free(lengthPtr);
+    calloc.free(sampleRatePtr);
+
+    return PcmData(buffer, sampleRate);
+  }
+}
+
+typedef _DecodeNative = Pointer<Uint8> Function(
+    Pointer<Utf8>, Pointer<Int32>, Pointer<Int32>);
+typedef _Decode = Pointer<Uint8> Function(
+    Pointer<Utf8>, Pointer<Int32>, Pointer<Int32>);
+
+typedef _FreeNative = Void Function(Pointer<Uint8>);
+typedef _Free = void Function(Pointer<Uint8>);

--- a/lib/modules/decoding/pcm_player.dart
+++ b/lib/modules/decoding/pcm_player.dart
@@ -1,0 +1,72 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart';
+
+/// FFI wrapper around a platform specific PCM audio player.
+class PcmPlayer {
+  final DynamicLibrary _lib;
+  late final _Create _create;
+  late final _Dispose _dispose;
+  late final _Load _load;
+  late final _Play _play;
+  late final _Pause _pause;
+  late final _Position _position;
+
+  late final int _handle;
+  bool _playing = false;
+
+  PcmPlayer({DynamicLibrary? library})
+      : _lib = library ?? DynamicLibrary.open('libaudioplayer.so') {
+    _create = _lib.lookupFunction<_CreateNative, _Create>('player_create');
+    _dispose = _lib.lookupFunction<_DisposeNative, _Dispose>('player_dispose');
+    _load = _lib.lookupFunction<_LoadNative, _Load>('player_load');
+    _play = _lib.lookupFunction<_PlayNative, _Play>('player_play');
+    _pause = _lib.lookupFunction<_PauseNative, _Pause>('player_pause');
+    _position =
+        _lib.lookupFunction<_PositionNative, _Position>('player_position');
+    _handle = _create();
+  }
+
+  Future<void> load(Uint8List pcm, int sampleRate) async {
+    final ptr = calloc<Uint8>(pcm.length);
+    ptr.asTypedList(pcm.length).setAll(0, pcm);
+    _load(_handle, ptr, pcm.length, sampleRate);
+    calloc.free(ptr);
+  }
+
+  Future<void> play() async {
+    _play(_handle);
+    _playing = true;
+  }
+
+  Future<void> pause() async {
+    _pause(_handle);
+    _playing = false;
+  }
+
+  Duration get position => Duration(milliseconds: _position(_handle));
+  bool get playing => _playing;
+
+  Future<void> dispose() async {
+    _dispose(_handle);
+  }
+}
+
+typedef _CreateNative = Int32 Function();
+typedef _Create = int Function();
+
+typedef _DisposeNative = Void Function(Int32);
+typedef _Dispose = void Function(int);
+
+typedef _LoadNative = Void Function(
+    Int32, Pointer<Uint8>, Int32, Int32);
+typedef _Load = void Function(int, Pointer<Uint8>, int, int);
+
+typedef _PlayNative = Void Function(Int32);
+typedef _Play = void Function(int);
+
+typedef _PauseNative = Void Function(Int32);
+typedef _Pause = void Function(int);
+
+typedef _PositionNative = Int64 Function(Int32);
+typedef _Position = int Function(int);

--- a/lib/modules/editing/AudioTrackWidget.dart
+++ b/lib/modules/editing/AudioTrackWidget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:just_audio/just_audio.dart';
 
 /// 音軌編輯元件：只顯示圖示與操作按鈕，不顯示文字資訊
 class AudioTrackWidget extends StatelessWidget {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,10 @@ import Foundation
 
 import audio_session
 import file_picker
-import just_audio
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
-  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -82,7 +82,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
@@ -136,30 +136,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  just_audio:
-    dependency: "direct main"
-    description:
-      name: just_audio
-      sha256: "679637a3ec5b6e00f36472f5a3663667df00ee4822cbf5dafca0f568c710960a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.4"
-  just_audio_platform_interface:
-    dependency: transitive
-    description:
-      name: just_audio_platform_interface
-      sha256: "4cd94536af0219fa306205a58e78d67e02b0555283c1c094ee41e402a14a5c4a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.5.0"
-  just_audio_web:
-    dependency: transitive
-    description:
-      name: just_audio_web
-      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,9 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^10.2.0
-  just_audio: ^0.10.4
   audio_waveforms: ^1.3.0
   linked_scroll_controller: ^0.2.0
+  ffi: ^2.1.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add FFmpeg-based decoder and PCM player via FFI
- route SingleTrack and MultiTrackEditor playback through FFmpeg PCM stream
- remove just_audio and add ffi dependency

## Testing
- `./build_ffmpeg.sh` *(fails: No such file or directory for aarch64-linux-android21-clang)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a98164b0832884e129a192071c2b