### PR TITLE
feat: add mix bus for multitrack playback

### DIFF
--- a/lib/modules/editing/AudioTrackWidget.dart
+++ b/lib/modules/editing/AudioTrackWidget.dart
@@ -4,15 +4,10 @@ import 'package:flutter/material.dart';
 class AudioTrackWidget extends StatelessWidget {
   final AudioTrack track;
   final VoidCallback onDelete;
-  final VoidCallback onPlayPause;
-  final bool isPlaying;
-
   const AudioTrackWidget({
     super.key,
     required this.track,
     required this.onDelete,
-    required this.onPlayPause,
-    required this.isPlaying,
   });
 
   @override
@@ -25,10 +20,6 @@ class AudioTrackWidget extends StatelessWidget {
           children: [
             const Icon(Icons.music_note),
             const Spacer(),
-            IconButton(
-              icon: Icon(isPlaying ? Icons.pause : Icons.play_arrow),
-              onPressed: onPlayPause,
-            ),
             IconButton(icon: const Icon(Icons.delete), onPressed: onDelete),
           ],
         ),

--- a/lib/modules/editing/multitrack_editor.dart
+++ b/lib/modules/editing/multitrack_editor.dart
@@ -8,6 +8,7 @@ import 'package:clipnote_audio/modules/decoding/pcm_player.dart';
 import 'package:clipnote_audio/modules/editing/AudioTrackWidget.dart';
 import 'package:clipnote_audio/modules/editing/fft.dart';
 import 'package:clipnote_audio/modules/file_access/uploader.dart';
+import 'package:clipnote_audio/modules/merge_mix/mix_bus.dart';
 
 class SpectrumBar extends StatelessWidget {
   final List<double> spectrum;
@@ -44,18 +45,16 @@ class MultiTrackEditor extends StatefulWidget {
 
 class _MultiTrackEditorState extends State<MultiTrackEditor> {
   final _uploader = FileUploader();
-  final Map<String, List<double>> _pcmData = {};
-  final Map<String, PcmPlayer> _players = {};
   final List<AudioTrack> _tracks = [];
   bool _isPlayingAll = false;
   List<double> _mixedSpectrum = [];
   Timer? _mixerTimer;
+  MixBus? _mixBus;
+  PcmPlayer? _player;
 
   @override
   void dispose() {
-    for (var player in _players.values) {
-      player.dispose();
-    }
+    _player?.dispose();
     _mixerTimer?.cancel();
     super.dispose();
   }
@@ -66,16 +65,11 @@ class _MultiTrackEditorState extends State<MultiTrackEditor> {
       final decoder = FFmpegDecoder();
       for (final path in paths) {
         final pcmData = decoder.decode(path);
-        final player = PcmPlayer();
-        await player.load(pcmData.buffer, pcmData.sampleRate);
-
-        final samples = Int16List.view(pcmData.buffer.buffer)
-            .map((s) => s.toDouble())
-            .toList();
-        _pcmData[path] = samples;
-        _players[path] = player;
+        _mixBus ??= MixBus(pcmData.sampleRate);
+        _mixBus!.addTrack(path, pcmData.buffer);
         _tracks.add(AudioTrack(path));
       }
+      await _reloadPlayer();
       _startMixerLoop();
       setState(() {});
     }
@@ -84,38 +78,36 @@ class _MultiTrackEditorState extends State<MultiTrackEditor> {
   void _startMixerLoop() {
     _mixerTimer?.cancel();
     _mixerTimer = Timer.periodic(const Duration(milliseconds: 200), (_) {
-      const sampleRate = 44100;
+      if (_mixBus == null || _player == null) return;
       const windowSize = 1024;
-
-      List<double> mixed = List.filled(windowSize, 0.0);
-      for (final track in _tracks) {
-        final pcm = _pcmData[track.filePath];
-        final player = _players[track.filePath];
-        if (pcm == null || player == null) continue;
-        if (pcm.length < windowSize) continue;
-
-        final posMs = player.position.inMilliseconds;
-        final center = (posMs / 1000 * sampleRate).toInt();
-        final rawStart = center - windowSize ~/ 2;
-        final maxStart = pcm.length - windowSize;
-        final start = math.max(0, math.min(rawStart, maxStart)).toInt();
-        final window = pcm.sublist(start, start + windowSize);
-
-        for (int i = 0; i < window.length; i++) {
-          mixed[i] += window[i];
-        }
-      }
-
-      final bins = spectrum500Hz(mixed, 44100.0);
+      final samples = Int16List.view(_mixBus!.output.buffer);
+      if (samples.length < windowSize) return;
+      final posMs = _player!.position.inMilliseconds;
+      final center = (posMs / 1000 * _mixBus!.sampleRate).toInt();
+      final rawStart = center - windowSize ~/ 2;
+      final maxStart = samples.length - windowSize;
+      final start = math.max(0, math.min(rawStart, maxStart));
+      final window =
+          samples.sublist(start, start + windowSize).map((s) => s.toDouble()).toList();
+      final bins = spectrum500Hz(window, _mixBus!.sampleRate.toDouble());
       setState(() => _mixedSpectrum = bins);
     });
   }
 
-  Future<void> _toggleAllPlayPause() async {
-    _isPlayingAll = !_isPlayingAll;
-    for (final player in _players.values) {
-      _isPlayingAll ? await player.play() : await player.pause();
+  Future<void> _reloadPlayer() async {
+    final data = _mixBus?.output;
+    if (data == null) return;
+    _player ??= PcmPlayer();
+    await _player!.load(data, _mixBus!.sampleRate);
+    if (_isPlayingAll) {
+      await _player!.play();
     }
+  }
+
+  Future<void> _toggleAllPlayPause() async {
+    if (_player == null) return;
+    _isPlayingAll = !_isPlayingAll;
+    _isPlayingAll ? await _player!.play() : await _player!.pause();
     setState(() {});
   }
 
@@ -146,19 +138,12 @@ class _MultiTrackEditorState extends State<MultiTrackEditor> {
             itemCount: _tracks.length,
             itemBuilder: (_, i) {
               final track = _tracks[i];
-              final player = _players[track.filePath]!;
               return AudioTrackWidget(
                 track: track,
-                isPlaying: player.playing,
-                onPlayPause: () async {
-                  player.playing ? await player.pause() : await player.play();
-                  setState(() {});
-                },
                 onDelete: () async {
-                  await player.dispose();
-                  _pcmData.remove(track.filePath);
-                  _players.remove(track.filePath);
+                  _mixBus?.removeTrack(track.filePath);
                   _tracks.removeAt(i);
+                  await _reloadPlayer();
                   setState(() {});
                 },
               );

--- a/lib/modules/merge_mix/mix_bus.dart
+++ b/lib/modules/merge_mix/mix_bus.dart
@@ -1,0 +1,57 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// MixBus 接受多條 PCM 音軌，於時間軸上對齊並加總產生混音結果。
+class MixBus {
+  final int sampleRate;
+  final Map<String, _Track> _tracks = {};
+  Uint8List? _cache;
+
+  MixBus(this.sampleRate);
+
+  /// 加入音軌資料 [pcm]，可指定起始位移 [offsetSamples]（單位：樣本）。
+  void addTrack(String id, Uint8List pcm, {int offsetSamples = 0}) {
+    _tracks[id] = _Track(Int16List.view(pcm.buffer), offsetSamples);
+    _cache = null;
+  }
+
+  /// 移除音軌
+  void removeTrack(String id) {
+    _tracks.remove(id);
+    _cache = null;
+  }
+
+  /// 取得混音後的 PCM 資料。
+  Uint8List get output {
+    _cache ??= _mix();
+    return _cache!;
+  }
+
+  Uint8List _mix() {
+    int length = 0;
+    for (final t in _tracks.values) {
+      length = math.max(length, t.offset + t.samples.length);
+    }
+    final mix32 = Int32List(length);
+    for (final t in _tracks.values) {
+      for (int i = 0; i < t.samples.length; i++) {
+        mix32[t.offset + i] += t.samples[i];
+      }
+    }
+    final out16 = Int16List(length);
+    for (int i = 0; i < length; i++) {
+      int v = mix32[i];
+      if (v > 32767) v = 32767;
+      if (v < -32768) v = -32768;
+      out16[i] = v;
+    }
+    return Uint8List.view(out16.buffer);
+  }
+}
+
+class _Track {
+  final Int16List samples;
+  final int offset;
+  _Track(this.samples, this.offset);
+}
+


### PR DESCRIPTION
## Summary
- add MixBus to align and sum multiple PCM tracks
- route MultiTrackEditor playback through MixBus and single PcmPlayer
- simplify AudioTrackWidget to show only delete control

## Testing
- `dart test` *(fails: `command not found: dart`)*

------
https://chatgpt.com/codex/tasks/task_e_6891ac251c20832894100f099c6bcf63