### PR TITLE
feat: handle platform-specific native libraries

### DIFF
--- a/lib/modules/decoding/ffmpeg_decoder.dart
+++ b/lib/modules/decoding/ffmpeg_decoder.dart
@@ -2,6 +2,8 @@ import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
 
+import 'native_library.dart';
+
 /// Holds decoded PCM data along with metadata like sample rate.
 class PcmData {
   final Uint8List buffer;
@@ -16,7 +18,7 @@ class FFmpegDecoder {
   late final _Free _free;
 
   FFmpegDecoder({DynamicLibrary? library})
-      : _lib = library ?? DynamicLibrary.open('libffmpeg.so') {
+      : _lib = library ?? loadNativeLibrary('ffmpeg') {
     _decode =
         _lib.lookupFunction<_DecodeNative, _Decode>('decode_audio');
     _free = _lib.lookupFunction<_FreeNative, _Free>('free_buffer');

--- a/lib/modules/decoding/native_library.dart
+++ b/lib/modules/decoding/native_library.dart
@@ -1,0 +1,24 @@
+import 'dart:ffi';
+import 'dart:io';
+
+DynamicLibrary loadNativeLibrary(String baseName) {
+  String ext;
+  if (Platform.isAndroid || Platform.isLinux) {
+    ext = '.so';
+  } else if (Platform.isWindows) {
+    ext = '.dll';
+  } else if (Platform.isMacOS) {
+    ext = '.dylib';
+  } else {
+    throw UnsupportedError('Unsupported platform');
+  }
+  final name = 'lib$baseName$ext';
+  try {
+    return DynamicLibrary.open(name);
+  } catch (e) {
+    final message =
+        'Failed to load native library $name. Ensure it is present for this platform.';
+    print(message);
+    throw Exception(message);
+  }
+}

--- a/lib/modules/decoding/pcm_player.dart
+++ b/lib/modules/decoding/pcm_player.dart
@@ -2,6 +2,8 @@ import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
 
+import 'native_library.dart';
+
 /// FFI wrapper around a platform specific PCM audio player.
 class PcmPlayer {
   final DynamicLibrary _lib;
@@ -16,7 +18,7 @@ class PcmPlayer {
   bool _playing = false;
 
   PcmPlayer({DynamicLibrary? library})
-      : _lib = library ?? DynamicLibrary.open('libaudioplayer.so') {
+      : _lib = library ?? loadNativeLibrary('audioplayer') {
     _create = _lib.lookupFunction<_CreateNative, _Create>('player_create');
     _dispose = _lib.lookupFunction<_DisposeNative, _Dispose>('player_dispose');
     _load = _lib.lookupFunction<_LoadNative, _Load>('player_load');


### PR DESCRIPTION
## Summary
- add shared helper to choose the native library extension via Platform
- reuse helper in FFmpegDecoder and PcmPlayer
- show a friendly message if the library fails to load

## Testing
- `dart format lib/modules/decoding/native_library.dart lib/modules/decoding/ffmpeg_decoder.dart lib/modules/decoding/pcm_player.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689369fbac3483288011a3c0260e9209