### PR TITLE
feat(editor): 互動拖曳+磁吸流程；重建 master 保留播放位置；修正拖曳後播放不同步

### DIFF
--- a/lib/modules/UI/ui2/ui2_pages.dart
+++ b/lib/modules/UI/ui2/ui2_pages.dart
@@ -1,6 +1,7 @@
 // ui2_pages.dart
 // ignore_for_file: unnecessary_this
 
+import 'package:clipnote_audio/modules/services/track_lane_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:clipnote_audio/modules/UI/ui2/ui2_primitives.dart'; // Glass
@@ -115,12 +116,14 @@ class _TracksPageState extends State<TracksPage> {
   static const double _followBias = 0.35; // 播放頭維持在右側 35% 位置
   static const double _edgeMargin = 120;
   static const Duration _animDur = Duration(milliseconds: 120);
+  late final TrackLaneService _laneSvc; // ★ 共用：一次只選一個 lane
 
   @override
   void initState() {
     super.initState();
     widget.editor.playhead.addListener(_onTick);
     widget.editor.playing.addListener(_maybeAutoFollow);
+    _laneSvc = TrackLaneService(widget.editor); // ★ 父層只建一次
   }
 
   @override
@@ -222,53 +225,76 @@ class _TracksPageState extends State<TracksPage> {
                 ),
                 itemCount: widget.tracks.length,
                 itemBuilder: (context, i) {
-                  final name = widget.tracks[i].name;
-                  final color = widget.tracks[i].color;
+                  final laneId = 'lane-$i';
+                  final trackSvc = widget.tracks[i];
 
-                  return SizedBox(
-                    height: _rowHeight,
-                    child: Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          // 左側控制欄
-                          SizedBox(
-                            width: _headerW,
-                            child: _TrackHeader(
-                              index: i,
-                              name: name,
-                              color: color,
-                              isMuted: widget.editor.trackMuted(i),
-                              gain: widget.editor.trackGain(i),
-                              onToggleMute: () =>
-                                  widget.editor.toggleTrackMute(i),
-                              onDelete: () => widget.onDeleteTrack(i),
-                              onGainChanged: (v) =>
-                                  widget.editor.setTrackGain(i, v),
-                            ),
-                          ),
-                          const SizedBox(width: _gutterW),
+                  return ValueListenableBuilder<String?>(
+                    valueListenable: _laneSvc.selectedLaneId,
+                    builder: (_, selectedLaneId, __) {
+                      final isSelectedLane = selectedLaneId == laneId;
 
-                          // 右側：音軌區（各自 controller，但已被群組連動）
-                          Expanded(
-                            child: ClipRRect(
+                      return SizedBox(
+                        height: _rowHeight,
+                        child: Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: isSelectedLane
+                                  ? const Color(0x1A22D3EE) // 淡青色高亮
+                                  : Colors.transparent,
                               borderRadius: BorderRadius.circular(10),
-                              child: TrackLane(
-                                track: widget.tracks[i],
-                                editor: widget.editor,
-                                pxPerMs: widget.pxPerMs,
-                                durationMs: widget.durationMs,
-                                canEdit: widget.canEdit,
-                                scrollController: _hGroup.controllerAt(i),
-                                showPlayhead: false, // 由父層畫公共紅線
-                                autoFollow: false, // 由父層統一追隨
-                              ),
+                            ),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                // 左側控制欄
+                                SizedBox(
+                                  width: _headerW,
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.opaque,
+                                    onTap: () => _laneSvc.selectLane(
+                                      laneId,
+                                    ), // ★ 點 header 即選 lane
+                                    child: _TrackHeader(
+                                      index: i,
+                                      name: trackSvc.name,
+                                      color: trackSvc.color,
+                                      isMuted: widget.editor.trackMuted(i),
+                                      gain: widget.editor.trackGain(i),
+                                      onToggleMute: () =>
+                                          widget.editor.toggleTrackMute(i),
+                                      onDelete: () => widget.onDeleteTrack(i),
+                                      onGainChanged: (v) =>
+                                          widget.editor.setTrackGain(i, v),
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: _gutterW),
+
+                                // 右側：音軌區（各自 controller，但被 _hGroup 連動）
+                                Expanded(
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(10),
+                                    child: TrackLane(
+                                      laneId: laneId, // ★ 傳唯一 ID
+                                      laneSvc: _laneSvc, // ★ 共用 service（單一選取）
+                                      track: trackSvc,
+                                      editor: widget.editor,
+                                      pxPerMs: widget.pxPerMs,
+                                      durationMs: widget.durationMs,
+                                      canEdit: widget.canEdit,
+                                      scrollController: _hGroup.controllerAt(i),
+                                      showPlayhead: false, // 由父層畫公共紅線
+                                      autoFollow: false, // 由父層統一追隨
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                        ],
-                      ),
-                    ),
+                        ),
+                      );
+                    },
                   );
                 },
               ),

--- a/lib/modules/UI/ui2/ui2_track_lane.dart
+++ b/lib/modules/UI/ui2/ui2_track_lane.dart
@@ -1,28 +1,29 @@
 // lib/modules/UI/ui2/ui2_track_lane.dart
 import 'dart:math' as math;
+import 'package:clipnote_audio/modules/services/track_lane_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart'; // Alt 切換磁吸（桌面）
 import 'package:clipnote_audio/modules/services/singleTrackService.dart';
 import 'package:clipnote_audio/modules/services/mainEditorService.dart';
 
 class TrackLane extends StatefulWidget {
+  final String laneId; // 唯一 lane ID（例如 "lane-0"）
+  final TrackLaneService laneSvc; // 共用 Service（父層傳入）
   final SingleTrackService track;
   final MainEditorService editor;
   final double pxPerMs;
   final int durationMs; // 編輯器總長（用來算寬度）
   final bool canEdit;
 
-  // ★ 新增：共用的水平 ScrollController（若未提供就用內建）
-  final ScrollController? scrollController;
-
-  // ★ 新增：是否在本 lane 畫播放頭（預設 false；通常由父層統一畫一條）
-  final bool showPlayhead;
-
-  // ★ 新增：是否啟用「本 lane 自動追隨播放頭」（父層控卷軸時設 false）
-  final bool autoFollow;
+  final ScrollController? scrollController; // 共用水平卷軸（可選）
+  final bool showPlayhead; // 是否在本 lane 畫播放頭
+  final bool autoFollow; // 是否啟用自動追隨
 
   const TrackLane({
     super.key,
+    required this.laneId,
+    required this.laneSvc,
     required this.track,
     required this.editor,
     required this.pxPerMs,
@@ -42,14 +43,18 @@ class _TrackLaneState extends State<TrackLane> {
   ScrollController get _sc => widget.scrollController ?? _ownSc;
 
   // 使用者主動捲動或拖曳時，暫停自動追隨
+  bool get _userDraggingSeg => widget.laneSvc.isDragging;
   bool _userScrolling = false;
-  bool _userDraggingSeg = false;
   double _viewportWidth = 0;
 
   // 追隨參數
   static const double _followBias = 0.35; // 播放頭落在視窗寬度的 35% 處
   static const double _edgeMargin = 120; // 播放頭距離邊緣 < 這個距離就自動捲
   static const Duration _animDur = Duration(milliseconds: 120);
+
+  // Alt 臨時關閉磁吸 + 鎖捲動
+  bool _snapOn = true;
+  bool _scrollLocked = false; // ★ 拖曳期間關閉水平滾動，避免手勢被 ScrollView 搶走
 
   @override
   void initState() {
@@ -59,6 +64,7 @@ class _TrackLaneState extends State<TrackLane> {
       widget.editor.playing.addListener(_maybeAutoFollow);
       widget.track.track.addListener(_maybeAutoFollow);
     }
+    RawKeyboard.instance.addListener(_onKey); // Alt 切換磁吸
   }
 
   @override
@@ -89,16 +95,25 @@ class _TrackLaneState extends State<TrackLane> {
       widget.editor.playing.removeListener(_maybeAutoFollow);
       widget.track.track.removeListener(_maybeAutoFollow);
     }
+    RawKeyboard.instance.removeListener(_onKey);
     _ownSc.dispose();
     super.dispose();
   }
 
+  // === 工具 ===
   int get _laneMs => math.max(widget.durationMs, widget.track.durationMs);
   double ms2x(int ms) => ms * widget.pxPerMs;
 
+  void _onKey(RawKeyEvent e) {
+    final altNow =
+        RawKeyboard.instance.keysPressed.contains(LogicalKeyboardKey.altLeft) ||
+        RawKeyboard.instance.keysPressed.contains(LogicalKeyboardKey.altRight);
+    final newSnapOn = !altNow;
+    if (newSnapOn != _snapOn) setState(() => _snapOn = newSnapOn);
+  }
+
   void _maybeAutoFollow() {
     if (!mounted || !widget.autoFollow) return;
-    // 僅在播放且非使用者主動操作時追隨
     if (!widget.editor.isPlaying || _userScrolling || _userDraggingSeg) return;
     if (!_sc.hasClients || _viewportWidth <= 0) return;
 
@@ -109,12 +124,10 @@ class _TrackLaneState extends State<TrackLane> {
     final left = _sc.position.pixels;
     final right = left + _viewportWidth;
 
-    // 播放頭已經在安全區域內就不動
     final safeLeft = left + _edgeMargin;
     final safeRight = right - _edgeMargin;
     if (playheadX >= safeLeft && playheadX <= safeRight) return;
 
-    // 目標：把播放頭放在視窗寬度的 _followBias 處
     double targetLeft = playheadX - _viewportWidth * _followBias;
     final maxScroll = math.max(0.0, laneWidth - _viewportWidth);
     targetLeft = targetLeft.clamp(0.0, maxScroll);
@@ -122,43 +135,79 @@ class _TrackLaneState extends State<TrackLane> {
     _sc.animateTo(targetLeft, duration: _animDur, curve: Curves.easeOut);
   }
 
-  // === 片段拖曳 ===
-  Segment? _dragging;
-  int _dragStartMs = 0;
-  double _dragStartDx = 0;
-
-  void _onPanStart(Segment seg, DragStartDetails d) {
-    if (!widget.canEdit) return;
-    _dragging = seg;
-    _dragStartDx = d.localPosition.dx;
-    _dragStartMs = seg.dstOffsetMs;
-    _userDraggingSeg = true;
-    widget.editor.beginInteractiveEdit();
-  }
-
-  void _onPanUpdate(Segment seg, DragUpdateDetails d) {
-    if (!widget.canEdit || _dragging == null) return;
-    final dx = d.localPosition.dx - _dragStartDx;
-    final rawMs = (_dragStartMs + dx / widget.pxPerMs).round();
-    widget.editor.updateInteractiveDrag(
-      track: widget.track,
-      segment: seg,
-      rawMs: rawMs.clamp(0, _laneMs),
-      excludeId: seg.id,
-    );
-    setState(() {}); // 讓 UI 跟著動
-  }
-
-  void _onPanEnd(_) async {
-    if (!widget.canEdit) return;
-    _dragging = null;
-    _userDraggingSeg = false;
-    await widget.editor.endInteractiveEdit();
-  }
-
-  void _onTapDown(TapDownDetails d) {
+  // === 背景/片段互動 ===
+  void _onBackgroundTapUp(TapUpDetails d) {
+    widget.laneSvc.clearSelection(); // 點空白清除選取
     final ms = (d.localPosition.dx / widget.pxPerMs).round().clamp(0, _laneMs);
     widget.editor.seekTo(ms);
+  }
+
+  void _onSegmentTap(Segment seg) {
+    widget.laneSvc.selectSegment(laneId: widget.laneId, segId: seg.id);
+  }
+
+  // --- 片段拖曳（用 HorizontalDrag，並在 pointer down 鎖滾動） ---
+  void _onDragDown(PointerDownEvent _) {
+    // 指針按下就先鎖滾動，避免手勢被 ScrollView 搶走
+    if (!_scrollLocked) setState(() => _scrollLocked = true);
+  }
+
+  // ★ 提交目前 segment 的最終位置（寫回資料層）
+  void _commitSegment(Segment seg) {
+    widget.track.setSegmentOffset(seg, newDstOffsetMs: seg.dstOffsetMs);
+  }
+
+  void _onHorizontalDragStart(Segment seg, DragStartDetails d) {
+    if (!widget.canEdit) return;
+
+    final started = widget.laneSvc.panStart(
+      laneId: widget.laneId,
+      track: widget.track,
+      segment: seg,
+      localDx: d.localPosition.dx,
+    );
+
+    // 若是「第一次只是選取」，這次拖曳不啟動：解鎖滾動（讓使用者再拖一次就會真的拖）
+    if (!started) {
+      if (_scrollLocked) setState(() => _scrollLocked = false);
+      return;
+    }
+    // started == true：維持鎖滾動直到拖曳結束
+  }
+
+  void _onHorizontalDragUpdate(Segment seg, DragUpdateDetails d) {
+    if (!widget.canEdit || !widget.laneSvc.isDragging) return;
+
+    widget.laneSvc.panUpdate(
+      localDx: d.localPosition.dx,
+      pxPerMs: widget.pxPerMs,
+      laneMs: _laneMs,
+      snappingEnabled: _snapOn,
+    );
+
+    widget.laneSvc.autoScrollWhileDragging(
+      controller: _sc,
+      viewportWidth: _viewportWidth,
+      pxPerMs: widget.pxPerMs,
+      laneMs: _laneMs,
+      edgeMargin: _edgeMargin,
+    );
+
+    setState(() {}); // 僅移動 Positioned
+  }
+
+  Future<void> _onHorizontalDragEnd(Segment seg, _) async {
+    if (!widget.canEdit) return;
+    _commitSegment(seg); // 保險提交
+    await widget.laneSvc.panEnd(postSeekMs: seg.dstOffsetMs); // ★ 傳新位置
+    if (_scrollLocked) setState(() => _scrollLocked = false);
+  }
+
+  void _onDragCancelFor(Segment seg) async {
+    if (_scrollLocked) setState(() => _scrollLocked = false);
+    if (!widget.canEdit) return;
+    _commitSegment(seg); // 保險提交
+    await widget.laneSvc.panEnd(postSeekMs: seg.dstOffsetMs); // ★ 傳新位置
   }
 
   @override
@@ -167,6 +216,8 @@ class _TrackLaneState extends State<TrackLane> {
       widget.track.track,
       widget.editor.playhead,
       widget.editor.snapGuide,
+      widget.laneSvc.selectedLaneId, // 當前被選的 lane
+      widget.laneSvc.selectedSegmentId, // 當前被選的 segment
     ]);
 
     final laneWidth = ms2x(_laneMs) + 40;
@@ -174,7 +225,6 @@ class _TrackLaneState extends State<TrackLane> {
     return LayoutBuilder(
       builder: (context, constraints) {
         _viewportWidth = constraints.maxWidth;
-        // 每次版面改變時嘗試自動追隨一次
         WidgetsBinding.instance.addPostFrameCallback((_) => _maybeAutoFollow());
 
         return ClipRRect(
@@ -188,7 +238,6 @@ class _TrackLaneState extends State<TrackLane> {
                   onNotification: (n) {
                     if (n is UserScrollNotification &&
                         n.metrics.axis == Axis.horizontal) {
-                      // 使用者主動滾動 → 暫停追隨；停止 800ms 後恢復
                       if (n.direction != ScrollDirection.idle) {
                         _userScrolling = true;
                       } else {
@@ -202,13 +251,24 @@ class _TrackLaneState extends State<TrackLane> {
                     return false;
                   },
                   child: SingleChildScrollView(
-                    controller: _sc, // ★ 使用共用 controller
+                    controller: _sc,
                     scrollDirection: Axis.horizontal,
+                    physics: _scrollLocked
+                        ? const NeverScrollableScrollPhysics() // ★ 拖曳時關閉水平滾動
+                        : const ClampingScrollPhysics(),
                     child: SizedBox(
                       width: laneWidth,
                       height: double.infinity,
                       child: Stack(
                         children: [
+                          // 0) 背景點擊 Seek（置底）
+                          Positioned.fill(
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.deferToChild,
+                              onTapUp: _onBackgroundTapUp,
+                              child: const SizedBox.expand(),
+                            ),
+                          ),
                           // 1) 背景網格
                           CustomPaint(
                             size: Size(laneWidth, double.infinity),
@@ -227,23 +287,38 @@ class _TrackLaneState extends State<TrackLane> {
                           ...widget.track.track.segments.map((seg) {
                             final x = ms2x(seg.dstOffsetMs);
                             final w = math.max(32.0, ms2x(seg.srcDurationMs));
+                            final selected =
+                                widget.laneSvc.isLaneSelected(widget.laneId) &&
+                                widget.laneSvc.isSegmentSelected(seg.id);
+
                             return Positioned(
                               left: x,
                               top: 6,
                               width: w,
                               bottom: 6,
-                              child: GestureDetector(
-                                behavior: HitTestBehavior.opaque,
-                                onPanStart: (d) => _onPanStart(seg, d),
-                                onPanUpdate: (d) => _onPanUpdate(seg, d),
-                                onPanEnd: _onPanEnd,
-                                child: _SegmentCard(
-                                  name: widget.track.name,
-                                  color: widget.track.color,
-                                  fadeInMs: seg.fadeInMs,
-                                  fadeOutMs: seg.fadeOutMs,
-                                  durationMs: seg.srcDurationMs,
-                                  pxPerMs: widget.pxPerMs,
+                              child: Listener(
+                                // ★ 先攔截 pointerDown 來鎖捲動
+                                onPointerDown: _onDragDown,
+                                child: GestureDetector(
+                                  behavior: HitTestBehavior.opaque,
+                                  onTap: () => _onSegmentTap(seg), // 點一下先選取
+                                  onHorizontalDragStart: (d) =>
+                                      _onHorizontalDragStart(seg, d),
+                                  onHorizontalDragUpdate: (d) =>
+                                      _onHorizontalDragUpdate(seg, d),
+                                  onHorizontalDragEnd: (d) =>
+                                      _onHorizontalDragEnd(seg, d), // ★ 傳 seg
+                                  onHorizontalDragCancel: () =>
+                                      _onDragCancelFor(seg), // ★ 取消也提交
+                                  child: _SegmentCard(
+                                    name: widget.track.name,
+                                    color: widget.track.color,
+                                    fadeInMs: seg.fadeInMs,
+                                    fadeOutMs: seg.fadeOutMs,
+                                    durationMs: seg.srcDurationMs,
+                                    pxPerMs: widget.pxPerMs,
+                                    selected: selected,
+                                  ),
                                 ),
                               ),
                             );
@@ -276,13 +351,6 @@ class _TrackLaneState extends State<TrackLane> {
                                 ),
                               ),
                             ),
-                          // 6) 點擊 Seek
-                          Positioned.fill(
-                            child: GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTapDown: _onTapDown,
-                            ),
-                          ),
                         ],
                       ),
                     ),
@@ -297,7 +365,7 @@ class _TrackLaneState extends State<TrackLane> {
   }
 }
 
-// === 以下畫 UI 的小類保持不變 ===
+// === 以下畫 UI 的小類保持不變（SegmentCard 多一個 selected 參數） ===
 
 class _SegmentCard extends StatelessWidget {
   final String name;
@@ -306,6 +374,7 @@ class _SegmentCard extends StatelessWidget {
   final int fadeOutMs;
   final int durationMs;
   final double pxPerMs;
+  final bool selected;
 
   const _SegmentCard({
     required this.name,
@@ -314,17 +383,31 @@ class _SegmentCard extends StatelessWidget {
     required this.fadeOutMs,
     required this.durationMs,
     required this.pxPerMs,
+    required this.selected,
   });
 
   @override
   Widget build(BuildContext context) {
     final bg = color.withOpacity(0.18);
     final bd = color.withOpacity(0.85);
-    return Container(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
       decoration: BoxDecoration(
         color: bg,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: bd, width: 1),
+        border: Border.all(
+          color: selected ? Colors.cyanAccent : bd,
+          width: selected ? 2 : 1,
+        ),
+        boxShadow: selected
+            ? [
+                BoxShadow(
+                  color: Colors.cyanAccent.withOpacity(0.25),
+                  blurRadius: 12,
+                  spreadRadius: 2,
+                ),
+              ]
+            : const [],
       ),
       child: Stack(
         children: [

--- a/lib/modules/editing/snapping.dart
+++ b/lib/modules/editing/snapping.dart
@@ -5,24 +5,29 @@ import 'dart:math' as math;
 class SnapPoint {
   final int ms;
   final String tag; // e.g. 'clip-start', 'clip-end', 'playhead', 'grid'
-  SnapPoint(this.ms, this.tag);
+  const SnapPoint(this.ms, this.tag);
 }
 
 /// 吸附結果（若不在門檻內，return null）
 class SnapResult {
-  final int snappedMs; // 吸附後的位置
+  final int snappedMs; // 吸附後的位置（已 clamp）
   final SnapPoint target; // 吸附到誰
   final int deltaAbs; // 吸附距離 |raw - snapped|
-  SnapResult(this.snappedMs, this.target, this.deltaAbs);
+  const SnapResult(this.snappedMs, this.target, this.deltaAbs);
 }
 
-/// 設定檔：要不要對齊哪些東西、門檻、網格大小等
+/// 設定檔：要不要對齊哪些東西、門檻、網格大小與優先順序
 class SnapConfig {
   final bool toClips;
   final bool toPlayhead;
   final bool toGrid;
   final int thresholdMs; // 距離門檻（越小越精準）
-  final int gridStepMs; // 網格間距（例如 250ms / 500ms / 1000ms）
+  final int gridStepMs; // 網格間距（例如 250/500/1000）
+  /// 同距離/臨界時的優先順序（越前越優先）
+  final List<String>
+  priority; // e.g. ['clip-start','clip-end','playhead','grid']
+  /// 黏滯釋放額外容差（避免在臨界值附近閃爍）
+  final int releaseGapMs;
 
   const SnapConfig({
     this.toClips = true,
@@ -30,6 +35,8 @@ class SnapConfig {
     this.toGrid = true,
     this.thresholdMs = 18,
     this.gridStepMs = 500,
+    this.priority = const ['clip-start', 'clip-end', 'playhead', 'grid'],
+    this.releaseGapMs = 6,
   });
 
   SnapConfig copyWith({
@@ -38,6 +45,8 @@ class SnapConfig {
     bool? toGrid,
     int? thresholdMs,
     int? gridStepMs,
+    List<String>? priority,
+    int? releaseGapMs,
   }) {
     return SnapConfig(
       toClips: toClips ?? this.toClips,
@@ -45,6 +54,8 @@ class SnapConfig {
       toGrid: toGrid ?? this.toGrid,
       thresholdMs: thresholdMs ?? this.thresholdMs,
       gridStepMs: gridStepMs ?? this.gridStepMs,
+      priority: priority ?? this.priority,
+      releaseGapMs: releaseGapMs ?? this.releaseGapMs,
     );
   }
 }
@@ -57,7 +68,7 @@ class SnapController {
   /// excludeId：排除自己（避免吸到自己邊緣）
   final List<SnapPoint> Function({String? excludeId}) getClipEdgePoints;
 
-  /// 播放頭與總時長（for grid/playhead）
+  /// 播放頭與總時長（for grid/playhead/clamp）
   final int Function() getPlayheadMs;
   final int Function() getDurationMs;
 
@@ -68,53 +79,103 @@ class SnapController {
     this.config = const SnapConfig(),
   });
 
-  /// 對單一原始位置作吸附；回傳最佳目標或 null（表示不吸）
-  SnapResult? snapMs(int rawMs, {String? excludeId}) {
-    final candidates = <SnapPoint>[];
+  // ---- 內部狀態：黏滯 & buffer（效能） ----
+  SnapPoint? _latched; // 已咬住的目標
+  final List<SnapPoint> _buf = <SnapPoint>[]; // 重用，避免反覆配置
 
+  /// 建議在 onPanStart 時呼叫
+  void beginDrag() => _latched = null;
+
+  /// 建議在 onPanEnd 時呼叫
+  void endDrag() => _latched = null;
+
+  /// 對單一原始位置作吸附；回傳最佳目標或 null（表示不吸）。
+  /// 可用 snappingEnabled 在 UI 端快速關閉（例如按住 Alt）。
+  SnapResult? snapMs(
+    int rawMs, {
+    String? excludeId,
+    bool snappingEnabled = true,
+  }) {
+    final total = getDurationMs();
+    final clampedRaw = rawMs.clamp(0, total);
+
+    if (!snappingEnabled || config.thresholdMs <= 0) return null;
+
+    // 收集候選點（順序不重要，後面會依優先權挑）
+    _buf.clear();
     if (config.toClips) {
-      candidates.addAll(getClipEdgePoints(excludeId: excludeId));
+      _buf.addAll(getClipEdgePoints(excludeId: excludeId));
     }
-
     if (config.toPlayhead) {
-      candidates.add(SnapPoint(getPlayheadMs(), 'playhead'));
+      _buf.add(SnapPoint(getPlayheadMs(), 'playhead'));
     }
-
     if (config.toGrid) {
-      candidates.addAll(
-        _gridNeighbors(rawMs, config.gridStepMs, getDurationMs()),
-      );
+      _buf.addAll(_gridNeighbors(clampedRaw as int, config.gridStepMs, total));
     }
+    if (_buf.isEmpty) return null;
 
-    // 從所有候選找距離最近者
-    SnapPoint? best;
-    var bestDelta = 1 << 30;
-    for (final p in candidates) {
-      final d = (p.ms - rawMs).abs();
-      if (d < bestDelta) {
-        bestDelta = d;
-        best = p;
+    // 黏滯：若已咬住，且仍在門檻 + releaseGap 內，就直接用它
+    if (_latched != null) {
+      final d = (clampedRaw - _latched!.ms).abs();
+      if (d <= config.thresholdMs + config.releaseGapMs) {
+        return SnapResult(_latched!.ms, _latched!, d);
       }
     }
-    if (best == null) return null;
 
-    // 只有在門檻內才吸
-    if (bestDelta <= config.thresholdMs) {
-      return SnapResult(best.ms, best, bestDelta);
+    // 依優先權 + 距離選擇最佳點（先比 priority，再比距離，再比較小的 ms）
+    SnapPoint? best;
+    var bestDelta = 1 << 30;
+    var bestRank = 999;
+
+    for (final p in _buf) {
+      final d = (p.ms - clampedRaw).abs();
+      final rank = _tagRank(p.tag);
+      final better =
+          (rank < bestRank) ||
+          (rank == bestRank && d < bestDelta) ||
+          (rank == bestRank && d == bestDelta && p.ms < (best?.ms ?? 1 << 30));
+      if (better) {
+        best = p;
+        bestDelta = d;
+        bestRank = rank;
+      }
+    }
+
+    // 只有在門檻內才吸；並「咬住」它
+    if (best != null && bestDelta <= config.thresholdMs) {
+      _latched = best;
+      final snapped = best.ms.clamp(0, total);
+      return SnapResult(snapped, best, bestDelta);
+    }
+
+    // 太遠：若離原先 latched 很遠，乾脆釋放
+    if (_latched != null &&
+        (clampedRaw - _latched!.ms).abs() >
+            config.thresholdMs + config.releaseGapMs * 2) {
+      _latched = null;
     }
     return null;
   }
 
-  /// 一次回兩三個最接近的網格點就好（不掃全局）
+  // 一次回 k-1、k、k+1 這三個最接近的網格點（含邊界）
   List<SnapPoint> _gridNeighbors(int rawMs, int step, int total) {
     if (step <= 0) return const [];
+    final out = <SnapPoint>[];
     final k = (rawMs / step).floor();
-    final msA = math.max(0, k * step);
-    final msB = math.min(total, (k + 1) * step);
-    final out = <SnapPoint>[SnapPoint(msA, 'grid')];
-    if (msB != msA) out.add(SnapPoint(msB, 'grid'));
-    // 也可加 k-1：
-    if (k - 1 >= 0) out.add(SnapPoint(math.max(0, (k - 1) * step), 'grid'));
+
+    int at(int idx) => (idx * step).clamp(0, total);
+    void push(int ms) {
+      if (out.isEmpty || out.last.ms != ms) out.add(SnapPoint(ms, 'grid'));
+    }
+
+    push(at(k - 1));
+    push(at(k));
+    push(at(k + 1));
     return out;
+  }
+
+  int _tagRank(String tag) {
+    final idx = config.priority.indexOf(tag);
+    return idx >= 0 ? idx : 99;
   }
 }

--- a/lib/modules/services/mainEditorService.dart
+++ b/lib/modules/services/mainEditorService.dart
@@ -1,8 +1,10 @@
+// lib/modules/services/mainEditorService.dart
 // ClipNote — MainEditorService（Lite：移除頻譜功能 + 互動編輯/磁吸）
 
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:file_picker/file_picker.dart';
 
@@ -11,34 +13,38 @@ import 'package:clipnote_audio/modules/services/singleTrackService.dart';
 import 'package:clipnote_audio/modules/merge_mix/mix_bus.dart';
 import 'package:clipnote_audio/modules/playback/playbackService.dart';
 
-// 自動對位（你之前加的）
+// 自動對位（磁吸）
 import 'package:clipnote_audio/modules/editing/snapping.dart';
 
 class MainEditorService extends ChangeNotifier {
   MainEditorService({PcmDecoder? decoder})
-    : _decoder = decoder ?? const FfmpegKitDecoder();
+    : _decoder = decoder ?? const FfmpegKitDecoder() {
+    // 初始化磁吸控制器：你提供了 getClipEdgePoints / getPlayheadMs / getDurationMs
+    snap = SnapController(
+      getClipEdgePoints: ({String? excludeId}) =>
+          _collectClipEdgePoints(excludeId: excludeId),
+      getPlayheadMs: () => playhead.value,
+      getDurationMs: () => durationMs,
+    );
+  }
 
+  // ===== 基本相依 =====
   final PcmDecoder _decoder;
-
-  // 狀態
-  final List<SingleTrackService> tracks = [];
   final PlaybackService _pb = PlaybackService.instance;
 
-  Uint8List? _masterPcmBytes; // s16le mono
+  // ===== 狀態 =====
+  final List<SingleTrackService> tracks = [];
+
+  Uint8List? _masterPcmBytes; // s16le mono（給電平/分析）
   int? _masterSampleRate;
 
   // UI notifiers
   final ValueNotifier<bool> playing = ValueNotifier(false);
   final ValueNotifier<int> playhead = ValueNotifier(0); // ms
   final ValueNotifier<double> meter = ValueNotifier(0); // 0..1
-
   Listenable get uiTick => Listenable.merge([playing, playhead, meter]);
 
-  // meter 視窗
-  static const int _meterWindow = 2048;
-  final Int16List _windowBuf = Int16List(_meterWindow);
-  final Int32List _accBuf = Int32List(_meterWindow);
-
+  // 播放與電平
   Timer? _uiTicker;
   double get volume01 => _pb.volume;
   int get durationMs => _pb.durationMs;
@@ -46,110 +52,58 @@ class MainEditorService extends ChangeNotifier {
   bool get isPlaying => playing.value;
   double get meterPeak01 => meter.value;
 
-  // —— Snapping —— //
-  final ValueNotifier<SnapPoint?> snapGuide = ValueNotifier<SnapPoint?>(null);
-  late final SnapController snap = SnapController(
-    getClipEdgePoints: ({String? excludeId}) =>
-        _collectClipEdgePoints(excludeId: excludeId),
-    getPlayheadMs: () => _pb.positionMs,
-    getDurationMs: () => durationMs,
-    config: const SnapConfig(
-      thresholdMs: 18,
-      gridStepMs: 500,
-      toClips: true,
-      toPlayhead: true,
-      toGrid: true,
-    ),
-  );
+  // ===== 電平視窗（極簡 Peak）=====
+  static const int _meterWindow = 2048;
+  final Int16List _windowBuf = Int16List(_meterWindow);
+  final Int32List _accBuf = Int32List(_meterWindow);
 
-  // NEW: 互動編輯旗標（拖曳中）
-  bool _interactiveEditing = false;
+  // ===== 重建節流 =====
+  Timer? _rebuildDebounce;
 
-  // === 放進 MainEditorService 類別內（任一成員區即可）===
+  // ===== 參考常數 =====
+  static const int _kSampleRate = 48000; // 引擎內部採樣率
 
-  // 建議把軌道增益限制在 -60 dB ~ 0 dB（0 dB = 1.0）
+  // ===== 軌道增益（dB 與 0..1 的互轉）=====
   static const double _gainDbMin = -60.0;
   static const double _gainDbMax = 0.0;
 
-  // 0..1 線性 → dB；0 代表靜音（取下限 -60 dB）
   double _gain01ToDb(double g) {
     if (g <= 0.0) return _gainDbMin;
     final db = 20.0 * (math.log(g) / math.ln10);
     return db.clamp(_gainDbMin, _gainDbMax);
   }
 
-  // dB → 0..1 線性；<= -60 dB 視為 0
   double _dbToGain01(double db) {
     if (db <= _gainDbMin) return 0.0;
     final g = math.pow(10.0, db / 20.0).toDouble();
-    // 極小值視覺上算 0，避免滑桿殘影
     return (g < 1e-3) ? 0.0 : g.clamp(0.0, 1.0);
   }
 
-  // 讀靜音狀態
   bool trackMuted(int i) {
     if (i < 0 || i >= tracks.length) return false;
     return tracks[i].isMuted;
   }
 
-  // 讀增益（0..1 給 UI Slider 用）
   double trackGain(int i) {
     if (i < 0 || i >= tracks.length) return 0.0;
     return _dbToGain01(tracks[i].trackGainDb);
   }
 
-  // ✅ 正確：呼叫 SingleTrackService.setMute()
   Future<void> toggleTrackMute(int i) async {
     if (i < 0 || i >= tracks.length) return;
     final t = tracks[i];
     t.setMute(!t.isMuted);
-    await rebuildMaster();
+    _scheduleRebuild();
   }
 
-  // ❌ 原本錯誤：tracks[i].trackGainDb = _gain01ToDb(gain01);
-  // ✅ 正確：呼叫 SingleTrackService.setTrackGainDb()
   Future<void> setTrackGain(int i, double gain01) async {
     if (i < 0 || i >= tracks.length) return;
     tracks[i].setTrackGainDb(_gain01ToDb(gain01));
-    await rebuildMaster();
+    _scheduleRebuild();
   }
 
-  Uint8List _pcmS16MonoToWav(Uint8List pcmS16le, int sampleRate) {
-    const int numChannels = 1;
-    const int bitsPerSample = 16;
-    final int byteRate = sampleRate * numChannels * (bitsPerSample >> 3);
-    final int blockAlign = numChannels * (bitsPerSample >> 3);
-    final int dataLen = pcmS16le.lengthInBytes;
-    final int totalLen = 44 + dataLen; // WAV header 44 bytes
-
-    final out = Uint8List(totalLen);
-    final bd = ByteData.sublistView(out);
-
-    // 'RIFF'
-    out.setAll(0, [0x52, 0x49, 0x46, 0x46]);
-    bd.setUint32(4, 36 + dataLen, Endian.little);
-    // 'WAVE'
-    out.setAll(8, [0x57, 0x41, 0x56, 0x45]);
-    // 'fmt '
-    out.setAll(12, [0x66, 0x6D, 0x74, 0x20]);
-    bd.setUint32(16, 16, Endian.little); // Subchunk1Size
-    bd.setUint16(20, 1, Endian.little); // AudioFormat=PCM
-    bd.setUint16(22, numChannels, Endian.little);
-    bd.setUint32(24, sampleRate, Endian.little);
-    bd.setUint32(28, byteRate, Endian.little);
-    bd.setUint16(32, blockAlign, Endian.little);
-    bd.setUint16(34, bitsPerSample, Endian.little);
-    // 'data'
-    out.setAll(36, [0x64, 0x61, 0x74, 0x61]);
-    bd.setUint32(40, dataLen, Endian.little);
-
-    // PCM payload
-    out.setRange(44, 44 + dataLen, pcmS16le);
-    return out;
-  }
-
+  // ===== 初始化 / 釋放 =====
   Future<void> initAsync() async {
-    // 預設兩條空軌（可直接拖片段進來）
     if (tracks.isEmpty) {
       tracks.add(
         SingleTrackService(decoder: _decoder, onChanged: _onTrackChanged),
@@ -159,16 +113,10 @@ class MainEditorService extends ChangeNotifier {
     _pullSampleWindow(); // 預熱電平
   }
 
-  void _onTrackChanged() {
-    // 若正在互動編輯，不主動重建 master；結束時統一重建
-    if (!_interactiveEditing) {
-      rebuildMaster();
-    }
-  }
-
   @override
   void dispose() {
     _uiTicker?.cancel();
+    _rebuildDebounce?.cancel();
     for (final t in tracks) {
       t.dispose();
     }
@@ -192,7 +140,7 @@ class MainEditorService extends ChangeNotifier {
         playing.value = true;
         _startUiTicker();
       } catch (e) {
-        debugPrint('Playback play failed: $e'); // 避免未處理例外
+        debugPrint('Playback play failed: $e');
         playing.value = false;
       }
     }
@@ -212,7 +160,7 @@ class MainEditorService extends ChangeNotifier {
     });
   }
 
-  // ===== 電平（略） =====
+  // ===== 電平（簡化：取峰值）=====
   void _pullSampleWindow() {
     if (_masterPcmBytes != null && _masterSampleRate != null) {
       final startSample = ((_pb.positionMs / 1000.0) * _masterSampleRate!)
@@ -222,6 +170,7 @@ class MainEditorService extends ChangeNotifier {
         startByte + (_meterWindow << 1),
         _masterPcmBytes!.length,
       );
+
       final view = ByteData.sublistView(_masterPcmBytes!);
       var peak = 0, o = 0;
       for (
@@ -254,10 +203,11 @@ class MainEditorService extends ChangeNotifier {
     var peak = 0;
     for (int i = 0; i < _meterWindow; i++) {
       int v = _accBuf[i];
-      if (v > 32767)
+      if (v > 32767) {
         v = 32767;
-      else if (v < -32768)
+      } else if (v < -32768) {
         v = -32768;
+      }
       _windowBuf[i] = v;
       final a = v >= 0 ? v : -v;
       if (a > peak) peak = a;
@@ -316,9 +266,11 @@ class MainEditorService extends ChangeNotifier {
     notifyListeners();
   }
 
-  // ===== 混音／載入播放器 =====
-  // 替換整個 _rebuildMasterAndLoad()
+  // ===== 混音／載入播放器（保留播放位置與狀態）=====
   Future<void> _rebuildMasterAndLoad() async {
+    final wasPlaying = _pb.isPlaying;
+    final keepPosMs = _pb.isLoaded ? _pb.positionMs : playhead.value;
+
     if (tracks.isEmpty) {
       _masterPcmBytes = null;
       _masterSampleRate = null;
@@ -328,11 +280,12 @@ class MainEditorService extends ChangeNotifier {
       return;
     }
 
+    // 準備每軌資料
     final pcmList = <Uint8List>[];
     final gainsDb = <double>[];
     final mutes = <bool>[];
     final solos = <bool>[];
-    const sr = kSampleRate;
+    const sr = _kSampleRate;
 
     for (final t in tracks) {
       final i16 = t.track.renderedPcm;
@@ -352,6 +305,7 @@ class MainEditorService extends ChangeNotifier {
       return;
     }
 
+    // 混音（非同步）
     final mix = await MixBus.mixAsync(
       tracksS16: pcmList,
       gainsDb: gainsDb,
@@ -360,11 +314,11 @@ class MainEditorService extends ChangeNotifier {
       sampleRate: sr,
     );
 
-    // 1) 電平/分析用：保留裸 PCM
+    // 給電平用的裸 PCM
     _masterPcmBytes = mix.pcmS16;
     _masterSampleRate = mix.sampleRate;
 
-    // 2) 播放器用：包成 WAV
+    // 播放用 WAV
     final wavBytes = _pcmS16MonoToWav(mix.pcmS16, mix.sampleRate);
 
     try {
@@ -374,14 +328,20 @@ class MainEditorService extends ChangeNotifier {
       rethrow;
     }
 
-    if (_pb.isPlaying) {
+    // 還原播放位置（夾在新時長範圍內）
+    final newDurMs = _pb.durationMs;
+    final targetMs = (keepPosMs.clamp(0, newDurMs)) as int;
+    await _pb.seekTo(targetMs);
+    playhead.value = _pb.positionMs;
+
+    // 還原播放狀態
+    if (wasPlaying) {
       await _pb.play();
       playing.value = true;
       _startUiTicker();
     } else {
       playing.value = false;
     }
-    playhead.value = _pb.positionMs;
   }
 
   Uint8List _i16ToBytes(Int16List i16) {
@@ -393,6 +353,7 @@ class MainEditorService extends ChangeNotifier {
     return out;
   }
 
+  // 對外 API
   Future<void> seekTo(int ms) async {
     if (!_pb.isLoaded) await _rebuildMasterAndLoad();
     await _pb.seekTo(ms);
@@ -406,50 +367,101 @@ class MainEditorService extends ChangeNotifier {
     notifyListeners();
   }
 
-  // ====== 互動編輯 API（給 Waveform 手勢用） ======
+  // ===== 內部：節流重建 =====
+  void _scheduleRebuild([Duration delay = const Duration(milliseconds: 120)]) {
+    if (_interactiveEditing) return; // 拖曳互動期間不重建
+    _rebuildDebounce?.cancel();
+    _rebuildDebounce = Timer(delay, () async {
+      await rebuildMaster();
+    });
+  }
+
+  void _onTrackChanged() {
+    if (_interactiveEditing) return; // 拖曳中只動 UI
+    _scheduleRebuild();
+  }
+
+  // --------------------------------------------------------------------------
+  // 互動編輯（拖曳＋磁吸）
+  // --------------------------------------------------------------------------
+
+  bool _interactiveEditing = false;
+  final Set<SingleTrackService> _touchedTracks = {};
+
+  // 導引線（UI 畫高亮）
+  final ValueNotifier<SnapPoint?> snapGuide = ValueNotifier<SnapPoint?>(null);
+
+  late final SnapController snap;
+
   void beginInteractiveEdit() {
+    if (_interactiveEditing) return;
     _interactiveEditing = true;
-    for (final t in tracks) {
-      t.setRenderSuspended(true);
-    }
-    // 清掉暫存指引線
+    _touchedTracks.clear();
+    snap.beginDrag();
     snapGuide.value = null;
   }
 
-  /// 拖曳中：回傳吸附後的位置（毫秒），同時只更新 UI，不重建
-  int updateInteractiveDrag({
+  /// 拖曳過程：更新該段的目的時間，但【不重建混音】
+  void updateInteractiveDrag({
     required SingleTrackService track,
     required Segment segment,
     required int rawMs,
+    required bool snappingEnabled,
     String? excludeId,
   }) {
-    final res = snap.snapMs(rawMs, excludeId: excludeId);
-    final snapMs = res?.snappedMs ?? rawMs;
-    if (res != null) snapGuide.value = res.target;
-    track.moveSegmentFast(segment, newDstOffsetMs: snapMs); // 不渲染
-    return snapMs;
+    // 第一次觸碰：暫停該軌渲染，避免每 1px 都重算
+    final firstTouch = _touchedTracks.add(track);
+    if (firstTouch) track.setRenderSuspended(true);
+
+    // 磁吸
+    int dst = rawMs;
+    final res = snap.snapMs(
+      rawMs,
+      excludeId: excludeId,
+      snappingEnabled: snappingEnabled,
+    );
+    if (res != null) {
+      dst = res.snappedMs;
+      snapGuide.value = res.target; // UI 畫導引線
+    } else {
+      snapGuide.value = null;
+    }
+
+    // 輕量位移（只改 segment.dstOffsetMs 與 UI）
+    track.moveSegmentFast(segment, newDstOffsetMs: dst);
   }
 
-  /// 結束拖曳：清指引線、恢復渲染，然後一次重建/混音
-  Future<void> endInteractiveEdit() async {
+  /// 放開手指/滑鼠：只重建 touched 軌 → 重建 master →（選擇性）seek
+  Future<void> endInteractiveEdit({int? postSeekMs}) async {
+    snap.endDrag();
+    final touched = List<SingleTrackService>.from(_touchedTracks);
+    _touchedTracks.clear();
+    _interactiveEditing = false;
     snapGuide.value = null;
-    for (final t in tracks) {
+
+    // 解除渲染暫停並同步重建這些軌
+    for (final t in touched) {
       t.setRenderSuspended(false);
       t.rebuildRenderedNow();
       t.buildDownsampledWaveform(step: 128);
     }
-    _interactiveEditing = false;
-    await rebuildMaster();
+
+    // 重建 master，保留原播放狀態/位置
+    await _rebuildMasterAndLoad();
+
+    // 如指定，跳到新的位置（例：段落新起點）
+    if (postSeekMs != null) {
+      final ms = (postSeekMs.clamp(0, durationMs)) as int;
+      await seekTo(ms);
+    }
   }
 
-  // —— 供磁吸掃描 —— //
+  // 收集可磁吸的片段邊緣
   List<SnapPoint> _collectClipEdgePoints({String? excludeId}) {
     final points = <SnapPoint>[];
     for (final t in tracks) {
-      final segs = t.track.segments;
-      for (final s in segs) {
-        final sid = (s.id ?? '').toString();
-        if (excludeId != null && sid == excludeId) continue;
+      for (final s in t.track.segments) {
+        if (excludeId != null && s.id == excludeId) continue;
         final start = s.dstOffsetMs;
         final end = start + s.srcDurationMs;
         points.add(SnapPoint(start, 'clip-start'));
@@ -457,5 +469,40 @@ class MainEditorService extends ChangeNotifier {
       }
     }
     return points;
+  }
+
+  // ===== WAV 封裝 =====
+  Uint8List _pcmS16MonoToWav(Uint8List pcmS16le, int sampleRate) {
+    const int numChannels = 1;
+    const int bitsPerSample = 16;
+    final int byteRate = sampleRate * numChannels * (bitsPerSample >> 3);
+    final int blockAlign = numChannels * (bitsPerSample >> 3);
+    final int dataLen = pcmS16le.lengthInBytes;
+    final int totalLen = 44 + dataLen; // WAV header 44 bytes
+
+    final out = Uint8List(totalLen);
+    final bd = ByteData.sublistView(out);
+
+    // 'RIFF'
+    out.setAll(0, [0x52, 0x49, 0x46, 0x46]);
+    bd.setUint32(4, 36 + dataLen, Endian.little);
+    // 'WAVE'
+    out.setAll(8, [0x57, 0x41, 0x56, 0x45]);
+    // 'fmt '
+    out.setAll(12, [0x66, 0x6D, 0x74, 0x20]);
+    bd.setUint32(16, 16, Endian.little); // Subchunk1Size
+    bd.setUint16(20, 1, Endian.little); // AudioFormat=PCM
+    bd.setUint16(22, numChannels, Endian.little);
+    bd.setUint32(24, sampleRate, Endian.little);
+    bd.setUint32(28, byteRate, Endian.little);
+    bd.setUint16(32, blockAlign, Endian.little);
+    bd.setUint16(34, bitsPerSample, Endian.little);
+    // 'data'
+    out.setAll(36, [0x64, 0x61, 0x74, 0x61]);
+    bd.setUint32(40, dataLen, Endian.little);
+
+    // PCM payload
+    out.setRange(44, 44 + dataLen, pcmS16le);
+    return out;
   }
 }

--- a/lib/modules/services/singleTrackService.dart
+++ b/lib/modules/services/singleTrackService.dart
@@ -282,16 +282,6 @@ class SingleTrackService {
     _touch();
   }
 
-  /// 拖曳過程快速移動（不進入 debounce、不重建）
-  void moveSegmentFast(Segment seg, {required int newDstOffsetMs}) {
-    final i = track.segments.indexOf(seg);
-    if (i < 0) return;
-    track.segments[i] = seg.copyWith(dstOffsetMs: newDstOffsetMs);
-    track.isDirty.value = true;
-    track.notifyListeners(); // 僅通知 UI 重畫
-    _onChanged?.call(); // 讓上層知道有改（MainEditor 會延後混音）
-  }
-
   void trimSegment(Segment seg, {int? newSrcStartMs, int? newSrcEndMs}) {
     final i = track.segments.indexOf(seg);
     if (i < 0) return;
@@ -564,5 +554,19 @@ class SingleTrackService {
     if (db <= kTrackGainDbMin) return 0.0;
     final g = math.pow(10.0, db / 20.0).toDouble();
     return (g < 1e-3) ? 0.0 : g.clamp(0.0, 1.0);
+  }
+
+  // ★ 拖曳中呼叫：只更新位置 + 輕量通知，千萬別觸發混音
+  void moveSegmentFast(Segment seg, {required int newDstOffsetMs}) {
+    if (seg.dstOffsetMs == newDstOffsetMs) return;
+    seg.dstOffsetMs = newDstOffsetMs;
+    _markChanged(); // ← 改這行：通知 track + 通知上層，而不是 notifyListeners()
+  }
+
+  // ★ 需要「正式寫回」才用這個（例如拖曳結束時）
+  void setSegmentOffset(Segment seg, {required int newDstOffsetMs}) {
+    if (seg.dstOffsetMs == newDstOffsetMs) return;
+    seg.dstOffsetMs = newDstOffsetMs;
+    _markChanged(); // ← 同上
   }
 }

--- a/lib/modules/services/track_lane_service.dart
+++ b/lib/modules/services/track_lane_service.dart
@@ -1,0 +1,167 @@
+// lib/modules/UI/ui2/track_lane_service.dart
+import 'dart:math' as math;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart'; // for ScrollController
+import 'package:clipnote_audio/modules/services/mainEditorService.dart';
+import 'package:clipnote_audio/modules/services/singleTrackService.dart';
+
+/// 將 TrackLane 的互動邏輯抽成 Service：
+/// - 單一選取：selectedLaneId + selectedSegmentId（全域唯一 lane）
+/// - 點擊先選取，再拖曳（未選取不進入拖曳）
+/// - 拖曳整合 Snapping（beginDrag/snapMs/endDrag）
+/// - 拖曳邊緣自動卷軸
+class TrackLaneService {
+  TrackLaneService(this.editor);
+
+  final MainEditorService editor;
+
+  /// 全域單一選取：只有一個 lane 可被選到
+  final ValueNotifier<String?> selectedLaneId = ValueNotifier<String?>(null);
+  final ValueNotifier<String?> selectedSegmentId = ValueNotifier<String?>(null);
+
+  bool isLaneSelected(String laneId) => selectedLaneId.value == laneId;
+  bool isSegmentSelected(String segId) => selectedSegmentId.value == segId;
+
+  void selectLane(String laneId) {
+    if (selectedLaneId.value != laneId) {
+      selectedLaneId.value = laneId;
+      selectedSegmentId.value = null; // 換 lane 即清掉 segment 選取
+    }
+  }
+
+  void selectSegment({required String laneId, required String segId}) {
+    if (selectedLaneId.value != laneId) {
+      selectedLaneId.value = laneId;
+    }
+    selectedSegmentId.value = segId;
+  }
+
+  void clearSelection() {
+    selectedLaneId.value = null;
+    selectedSegmentId.value = null;
+  }
+
+  // ---- 拖曳狀態 ----
+  _DragCtx? _drag;
+  bool get isDragging => _drag != null;
+
+  /// onPanStart：若尚未選取該段 -> 僅選取、不開拖曳；回傳是否真的開始拖曳
+  bool panStart({
+    required String laneId,
+    required SingleTrackService track,
+    required Segment segment,
+    required double localDx, // d.localPosition.dx
+  }) {
+    // 未選取 -> 只選取，不進入拖曳
+    if (!(isLaneSelected(laneId) && isSegmentSelected(segment.id))) {
+      selectSegment(laneId: laneId, segId: segment.id);
+      return false;
+    }
+
+    // 真的開始拖曳
+    _drag = _DragCtx(
+      laneId: laneId,
+      track: track,
+      segment: segment,
+      startDx: localDx,
+      startMs: segment.dstOffsetMs,
+    );
+    editor.beginInteractiveEdit();
+    editor.snap.beginDrag();
+    editor.snapGuide.value = null;
+    return true;
+  }
+
+  /// onPanUpdate：進行快移與磁吸（不做混音重建）
+  // lib/modules/UI/ui2/track_lane_service.dart
+
+  void panUpdate({
+    required double localDx,
+    required double pxPerMs,
+    required int laneMs,
+    required bool snappingEnabled,
+  }) {
+    final ctx = _drag;
+    if (ctx == null) return;
+
+    final dx = localDx - ctx.startDx;
+    final rawMs = (ctx.startMs + dx / pxPerMs).round().clamp(0, laneMs);
+
+    // ✅ 改成透過 Editor，會順便記錄 touchedTracks 與顯示 snap 導引線
+    editor.updateInteractiveDrag(
+      track: ctx.track,
+      segment: ctx.segment,
+      rawMs: rawMs,
+      excludeId: ctx.segment.id,
+      snappingEnabled: snappingEnabled,
+    );
+  }
+
+  /// onPanEnd：結束拖曳，這裡才觸發混音重建
+
+  // track_lane_service.dart
+  Future<void> panEnd({int? postSeekMs}) async {
+    final ctx = _drag;
+    if (ctx == null) return;
+
+    // 保險：提交最後位置
+    ctx.track.setSegmentOffset(
+      ctx.segment,
+      newDstOffsetMs: ctx.segment.dstOffsetMs,
+    );
+
+    _drag = null;
+    await editor.endInteractiveEdit(postSeekMs: postSeekMs); // ★ 傳入
+  }
+
+  // ---- 拖曳邊緣自動卷軸（節流） ----
+  DateTime _lastAutoScroll = DateTime.fromMillisecondsSinceEpoch(0);
+
+  void autoScrollWhileDragging({
+    required ScrollController controller,
+    required double viewportWidth,
+    required double pxPerMs,
+    required int laneMs,
+    double edgeMargin = 120,
+  }) {
+    if (_drag == null) return;
+    if (!controller.hasClients || viewportWidth <= 0) return;
+
+    final now = DateTime.now();
+    if (now.difference(_lastAutoScroll).inMilliseconds < 24) return;
+    _lastAutoScroll = now;
+
+    final laneWidth = laneMs * pxPerMs + 40;
+    final maxScroll = math.max(0.0, laneWidth - viewportWidth);
+    if (maxScroll <= 0) return;
+
+    final ms = _drag!.segment.dstOffsetMs;
+    final x = ms * pxPerMs;
+    var left = controller.position.pixels;
+    final right = left + viewportWidth;
+
+    const step = 32.0; // 每次小步移動（px）
+    if (x < left + edgeMargin) {
+      left = (left - step).clamp(0.0, maxScroll);
+      controller.jumpTo(left);
+    } else if (x > right - edgeMargin) {
+      left = (left + step).clamp(0.0, maxScroll);
+      controller.jumpTo(left);
+    }
+  }
+}
+
+class _DragCtx {
+  final String laneId;
+  final SingleTrackService track;
+  final Segment segment;
+  final double startDx;
+  final int startMs;
+  _DragCtx({
+    required this.laneId,
+    required this.track,
+    required this.segment,
+    required this.startDx,
+    required this.startMs,
+  });
+}


### PR DESCRIPTION
MainEditorService

新增三段式互動 API：beginInteractiveEdit / updateInteractiveDrag / endInteractiveEdit

以 _touchedTracks 僅重建被影響之軌的 rendered + waveform，最後再重建 master

_rebuildMasterAndLoad() 保留播放狀態與位置（seek 回 keepPosMs），避免回到 0ms

整合 SnapController（getClipEdgePoints/getPlayheadMs/getDurationMs），提供 snapGuide 供 UI 畫導引線

移除 舊用法 getGridPoints；對齊 snapping.dart 的介面

增加 Mute/Gain 變更之重建節流 _scheduleRebuild()

補齊 WAV 封裝、電平取樣、UI ticker 與資源釋放

TrackLaneService（用法同步）

拖曳中呼叫：editor.updateInteractiveDrag(track: ..., segment: ..., rawMs: ..., excludeId: ..., snappingEnabled: ...)

放手時呼叫：editor.endInteractiveEdit(postSeekMs: segment.dstOffsetMs)，立即跳到新位置

修復

修正「UI 片段已移動但實際播放仍在舊位置」的不同步問題

重建後立即 seek 到新位置，畫面與聲音一致

Test Plan

拖曳片段→放手：播放內容對應新位置；播放中拖曳可無卡頓，放手才重建

Mute/Gain 調整以 120ms 節流合併重建

匯入/刪除/排序音軌後能保留播放狀態與位置