### PR TITLE
feat(ui): 片段長按選單加入「刪除此段」並即時重建波形/混音

### DIFF
--- a/lib/modules/UI/ui2/ui2_track_lane.dart
+++ b/lib/modules/UI/ui2/ui2_track_lane.dart
@@ -1,4 +1,5 @@
 // lib/modules/UI/ui2/ui2_track_lane.dart
+import 'dart:async';
 import 'dart:math' as math;
 import 'package:clipnote_audio/modules/services/track_lane_service.dart';
 import 'package:flutter/material.dart';
@@ -210,6 +211,97 @@ class _TrackLaneState extends State<TrackLane> {
     await widget.laneSvc.panEnd(postSeekMs: seg.dstOffsetMs); // ★ 傳新位置
   }
 
+  Future<bool> _confirmDeleteSegment(BuildContext context, Segment seg) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('刪除此段？'),
+            content: Text(
+              '起點 ${seg.dstOffsetMs} ms、長度 ${seg.srcDurationMs} ms',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('取消'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('刪除'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+
+  Future<void> _onSegmentLongPressStart(
+    Segment seg,
+    LongPressStartDetails d,
+  ) async {
+    final pos = d.globalPosition;
+    final choice = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(pos.dx, pos.dy, pos.dx, pos.dy),
+      items: const [
+        PopupMenuItem(value: 'here', child: Text('在此處切割')),
+        PopupMenuItem(value: 'playhead', child: Text('在播放頭切割')),
+        PopupMenuItem(value: 'delete', child: Text('刪除此段')),
+      ],
+    );
+    if (choice == null) return;
+
+    if (choice == 'delete') {
+      final ok = await _confirmDeleteSegment(context, seg);
+      if (!ok) return;
+
+      // 找到目前索引，刪除後選鄰近
+      final segs = widget.track.track.segments;
+      final idx = segs.indexOf(seg);
+
+      widget.track.removeSegment(seg);
+      // 立即刷新本軌渲染與波形 & 主混音
+      widget.track.rebuildRenderedNow();
+      widget.track.buildDownsampledWaveform(step: 128);
+      await widget.editor.rebuildMaster();
+
+      // 選取鄰近片段（若還有片段）
+      if (segs.isNotEmpty) {
+        final pick = segs[idx.clamp(0, segs.length - 1)];
+        widget.laneSvc.selectSegment(laneId: widget.laneId, segId: pick.id);
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('已刪除 1 段')));
+        setState(() {});
+      }
+      return;
+    }
+
+    // 其餘：切割
+    int splitMs;
+    if (choice == 'here') {
+      splitMs = (seg.dstOffsetMs + d.localPosition.dx / widget.pxPerMs).round();
+    } else {
+      splitMs = widget.editor.playheadMs;
+    }
+    final start = seg.dstOffsetMs;
+    final end = start + seg.srcDurationMs;
+    splitMs = splitMs.clamp(start + 1, end - 1);
+
+    final res = widget.track.splitSegment(seg, splitMs);
+    if (res != null && mounted) {
+      widget.track.rebuildRenderedNow();
+      widget.track.buildDownsampledWaveform(step: 128);
+      await widget.editor.rebuildMaster();
+      widget.laneSvc.selectSegment(laneId: widget.laneId, segId: res.right.id);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('已分割')));
+      setState(() {});
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final listens = Listenable.merge([
@@ -310,6 +402,8 @@ class _TrackLaneState extends State<TrackLane> {
                                       _onHorizontalDragEnd(seg, d), // ★ 傳 seg
                                   onHorizontalDragCancel: () =>
                                       _onDragCancelFor(seg), // ★ 取消也提交
+                                  onLongPressStart: (d) =>
+                                      _onSegmentLongPressStart(seg, d),
                                   child: _SegmentCard(
                                     name: widget.track.name,
                                     color: widget.track.color,

--- a/lib/modules/services/singleTrackService.dart
+++ b/lib/modules/services/singleTrackService.dart
@@ -152,6 +152,13 @@ class UnimplementedDecoder implements PcmDecoder {
   }
 }
 
+/// 分割結果：左段 + 右段
+class SplitResult {
+  final Segment left;
+  final Segment right;
+  const SplitResult(this.left, this.right);
+}
+
 /// SingleTrackService：管理一條軌的全部行為
 class SingleTrackService {
   SingleTrackService({PcmDecoder? decoder, void Function()? onChanged})
@@ -185,6 +192,9 @@ class SingleTrackService {
   // 方便 UI：0..1 線性增益讀寫
   double get trackGain01 => _dbTo01(track.trackGainDb);
   void setTrackGain01(double g01) => setTrackGainDb(_toDb(g01));
+
+  /// 避免產生 0 長度段的最小切割距離
+  static const int kMinSplitMs = 5;
 
   // Toggle 便利方法
   void toggleMute() => setMute(!isMuted);
@@ -568,5 +578,83 @@ class SingleTrackService {
     if (seg.dstOffsetMs == newDstOffsetMs) return;
     seg.dstOffsetMs = newDstOffsetMs;
     _markChanged(); // ← 同上
+  }
+
+  /// 傳回「某毫秒落在哪一段」；若無則 null
+  Segment? segmentAtMs(int ms) {
+    for (final s in track.segments) {
+      final start = s.dstOffsetMs;
+      final end = start + s.srcDurationMs;
+      if (ms >= start && ms < end) return s;
+    }
+    return null;
+  }
+
+  /// 在指定段 seg 的 splitMs（絕對時間）處切割。
+  /// clearFadesAtCut=true 會把切點處的左右段淡出/淡入清零，避免切點音量凹陷。
+  SplitResult? splitSegment(
+    Segment seg,
+    int splitMs, {
+    bool clearFadesAtCut = true,
+  }) {
+    final segStart = seg.dstOffsetMs;
+    final segEnd = segStart + seg.srcDurationMs;
+    if (segEnd <= segStart) return null;
+
+    // 夾限切點在段內
+    final cut = splitMs.clamp(segStart, segEnd);
+
+    // 靠太近邊界就不切，避免 0 長度
+    if (cut - segStart < kMinSplitMs) return null;
+    if (segEnd - cut < kMinSplitMs) return null;
+
+    // 左段長度 = cut - segStart；對應到來源的 newSrcEndLeft
+    final leftDurMs = cut - segStart;
+    final newSrcEndLeft = seg.srcStartMs + leftDurMs;
+    final newSrcStartRight = newSrcEndLeft;
+
+    // 生成左右段（先複製，再調整）
+    final left = seg.copyWith(
+      id: _genId(),
+      srcEndMs: newSrcEndLeft,
+      // right 從 cut 起接上
+      // 保留 dstOffsetMs 不變（左段起點仍在 segStart）
+      fadeOutMs: clearFadesAtCut ? 0 : seg.fadeOutMs,
+    );
+    final right = seg.copyWith(
+      id: _genId(),
+      srcStartMs: newSrcStartRight,
+      dstOffsetMs: cut,
+      fadeInMs: clearFadesAtCut ? 0 : seg.fadeInMs,
+    );
+
+    // 夾限淡入/淡出不可超過新段長
+    Segment clampFades(Segment s) {
+      final len = s.srcDurationMs;
+      return s.copyWith(
+        fadeInMs: math.min(s.fadeInMs, len),
+        fadeOutMs: math.min(s.fadeOutMs, len),
+      );
+    }
+
+    final leftFixed = clampFades(left);
+    final rightFixed = clampFades(right);
+
+    // 用左右兩段取代原段，維持時間順序
+    final idx = track.segments.indexOf(seg);
+    if (idx < 0) return null;
+    track.segments
+      ..removeAt(idx)
+      ..insertAll(idx, [leftFixed, rightFixed]);
+
+    _touch(); // 標髒並觸發 debounce 渲染
+    return SplitResult(leftFixed, rightFixed);
+  }
+
+  /// 以絕對時間 ms 找段並切割（例如播放頭）
+  SplitResult? splitAtMs(int ms, {bool clearFadesAtCut = true}) {
+    final seg = segmentAtMs(ms);
+    if (seg == null) return null;
+    return splitSegment(seg, ms, clearFadesAtCut: clearFadesAtCut);
   }
 }


### PR DESCRIPTION
- ui2_track_lane.dart：
  - 長按片段彈出選單新增「刪除此段」
  - 刪除前加入確認對話框 _confirmDeleteSegment()
  - 刪除後立即：
    - track.removeSegment(seg)
    - track.rebuildRenderedNow()
    - track.buildDownsampledWaveform(step: 128)
    - editor.rebuildMaster()
  - 自動選取鄰近片段（若存在），維持編輯連續性
  - 保留原有「在此處切割 / 在播放頭切割」功能
  - 新增 Snackbar 回饋

UX:
- 長按片段可直接刪除該段，操作一致且有確認保護
- 刪除後波形與主混音即時更新，所見即所得

Notes:
- 無破壞性變更；僅 UI 行為擴充