### PR TITLE
feat(waveform,grid): 視窗式波形 + 動態格線；修正滑動不重繪/右滑消失；封包快取改為 per-track

### DIFF
--- a/lib/modules/UI/ui2/ui2_track_lane.dart
+++ b/lib/modules/UI/ui2/ui2_track_lane.dart
@@ -2,6 +2,8 @@
 import 'dart:async';
 import 'dart:math' as math;
 import 'package:clipnote_audio/modules/services/track_lane_service.dart';
+import 'package:clipnote_audio/modules/waveform/envelope.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart'; // Alt 切換磁吸（桌面）
@@ -56,16 +58,44 @@ class _TrackLaneState extends State<TrackLane> {
   // Alt 臨時關閉磁吸 + 鎖捲動
   bool _snapOn = true;
   bool _scrollLocked = false; // ★ 拖曳期間關閉水平滾動，避免手勢被 ScrollView 搶走
-
+  final ValueNotifier<double> _scrollLeftPx = ValueNotifier(0);
   @override
   void initState() {
     super.initState();
+    // 監聽自動追隨（原本就有的）
     if (widget.autoFollow) {
       widget.editor.playhead.addListener(_maybeAutoFollow);
       widget.editor.playing.addListener(_maybeAutoFollow);
       widget.track.track.addListener(_maybeAutoFollow);
     }
-    RawKeyboard.instance.addListener(_onKey); // Alt 切換磁吸
+    RawKeyboard.instance.addListener(_onKey);
+
+    // ★ 監聽水平滾動 → 更新 _scrollLeftPx
+    _sc.addListener(_onScrollChanged);
+    // 初始值
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (_sc.hasClients) _scrollLeftPx.value = _sc.position.pixels;
+    });
+  }
+
+  void _onScrollChanged() {
+    if (!_sc.hasClients) return;
+    _scrollLeftPx.value = _sc.position.pixels;
+  }
+
+  @override
+  void dispose() {
+    if (widget.autoFollow) {
+      widget.editor.playhead.removeListener(_maybeAutoFollow);
+      widget.editor.playing.removeListener(_maybeAutoFollow);
+      widget.track.track.removeListener(_maybeAutoFollow);
+    }
+    RawKeyboard.instance.removeListener(_onKey);
+    _sc.removeListener(_onScrollChanged); // ★ 解除
+    _scrollLeftPx.dispose(); // ★ 釋放
+    _ownSc.dispose();
+    super.dispose();
   }
 
   @override
@@ -116,18 +146,6 @@ class _TrackLaneState extends State<TrackLane> {
       widget.editor.playing.removeListener(_maybeAutoFollow);
       widget.track.track.removeListener(_maybeAutoFollow);
     }
-  }
-
-  @override
-  void dispose() {
-    if (widget.autoFollow) {
-      widget.editor.playhead.removeListener(_maybeAutoFollow);
-      widget.editor.playing.removeListener(_maybeAutoFollow);
-      widget.track.track.removeListener(_maybeAutoFollow);
-    }
-    RawKeyboard.instance.removeListener(_onKey);
-    _ownSc.dispose();
-    super.dispose();
   }
 
   // === 工具 ===
@@ -348,6 +366,17 @@ class _TrackLaneState extends State<TrackLane> {
         _viewportWidth = constraints.maxWidth;
         WidgetsBinding.instance.addPostFrameCallback((_) => _maybeAutoFollow());
 
+        // === 只畫視窗：算出目前可視區間 ===
+        final double leftPx = _sc.hasClients ? _sc.position.pixels : 0.0;
+        final double viewWidthPx = constraints.maxWidth;
+        final int viewMsStart = (leftPx / widget.pxPerMs).floor();
+        final int viewMsEnd =
+            viewMsStart + (viewWidthPx / widget.pxPerMs).ceil();
+
+        // 啟動一次非阻塞的封包確保（避免首次縮放/捲動卡頓）
+        unawaited(widget.track.ensureEnvelopeForPxPerMs(widget.pxPerMs));
+        // 拿到最接近 1px 一柱的封包層
+        final env = widget.track.pickEnvelopeForPxPerMs(widget.pxPerMs);
         return ClipRRect(
           borderRadius: BorderRadius.circular(10),
           child: Container(
@@ -391,19 +420,34 @@ class _TrackLaneState extends State<TrackLane> {
                             ),
                           ),
                           // 1) 背景網格
+                          // 1) 背景網格（動態刻度 + 只畫可視區間）
                           CustomPaint(
                             size: Size(laneWidth, double.infinity),
-                            painter: _GridPainter(pxPerMs: widget.pxPerMs),
-                          ),
-                          // 2) 波形
-                          CustomPaint(
-                            size: Size(laneWidth, double.infinity),
-                            painter: _WaveformPainter(
-                              peaks: widget.track.track.downsampledPcmPeak,
-                              stepSamples: widget.track.track.downsampleStep,
+                            painter: _GridPainterWindow(
                               pxPerMs: widget.pxPerMs,
+                              scrollLeftPx: _scrollLeftPx,
+                              viewportWidthPx: _viewportWidth,
                             ),
                           ),
+
+                          // 2) 波形
+                          // 2) 波形（只畫可視區間；滾動時自動 repaint）
+                          CustomPaint(
+                            size: Size(laneWidth, double.infinity),
+                            painter: _WaveformWindowPainter(
+                              env: widget.track.pickEnvelopeForPxPerMs(
+                                widget.pxPerMs,
+                              ),
+                              fallbackPeaks:
+                                  widget.track.track.downsampledPcmPeak,
+                              fallbackStepSamples:
+                                  widget.track.track.downsampleStep,
+                              pxPerMs: widget.pxPerMs,
+                              scrollLeftPx: _scrollLeftPx, // ★
+                              viewportWidthPx: _viewportWidth, // ★
+                            ),
+                          ),
+
                           // 3) 片段
                           ...widget.track.track.segments.map((seg) {
                             final x = ms2x(seg.dstOffsetMs);
@@ -603,24 +647,92 @@ class _FadeTrianglePainter extends CustomPainter {
       old.color != color || old.leftToRight != leftToRight;
 }
 
-class _GridPainter extends CustomPainter {
+class _GridPainterWindow extends CustomPainter {
   final double pxPerMs;
-  _GridPainter({required this.pxPerMs});
+  final ValueListenable<double> scrollLeftPx; // ← 用於滑動即時重繪
+  final double viewportWidthPx;
+
+  _GridPainterWindow({
+    required this.pxPerMs,
+    required this.scrollLeftPx,
+    required this.viewportWidthPx,
+  }) : super(repaint: scrollLeftPx);
+
+  // 推薦的時間刻度（毫秒）
+  static const List<int> _niceStepsMs = [
+    // 毫秒
+    1, 2, 5, 10, 20, 50, 100, 200, 500,
+    // 秒
+    1000, 2000, 5000, 10000, 15000, 30000,
+    // 分
+    60000, 120000, 300000, 600000, 1800000,
+    // 小時
+    3600000,
+  ];
+
+  // 依目前縮放挑一個「看起來舒服」的 major 刻度，目標線距 ~ 120px
+  static int _pickMajorMs(double pxPerMs, double viewportWidthPx) {
+    const desiredPx = 120.0;
+    for (final s in _niceStepsMs) {
+      if (s * pxPerMs >= desiredPx) return s;
+    }
+    return _niceStepsMs.last; // 超遠視野，用最大的
+  }
+
+  // 挑 minor 刻度，確保線距 ≥ 18px，否則就不要 minor
+  static int? _pickMinorMs(int majorMs, double pxPerMs) {
+    const minMinorPx = 18.0;
+    // 優先 1/6、1/5、1/4、1/2
+    for (final div in [6, 5, 4, 2]) {
+      if ((majorMs / div) * pxPerMs >= minMinorPx) {
+        return (majorMs / div).round();
+      }
+    }
+    return null; // 太擠就不畫 minor
+  }
 
   @override
   void paint(Canvas c, Size s) {
-    final pMinor = Paint()..color = const Color(0x22FFFFFF);
-    final pMajor = Paint()..color = const Color(0x44FFFFFF);
-    for (double x = 0; x < s.width; x += 100 * pxPerMs) {
-      c.drawLine(Offset(x, 0), Offset(x, s.height), pMinor);
+    final leftPx = scrollLeftPx.value;
+    final viewMsStart = (leftPx / pxPerMs).floor();
+    final viewMsEnd = viewMsStart + (viewportWidthPx / pxPerMs).ceil();
+
+    final majorMs = _pickMajorMs(pxPerMs, viewportWidthPx);
+    final minorMs = _pickMinorMs(majorMs, pxPerMs);
+
+    final pMinor = Paint()
+      ..color = const Color(0x22FFFFFF)
+      ..strokeWidth = 1;
+    final pMajor = Paint()
+      ..color = const Color(0x44FFFFFF)
+      ..strokeWidth = 1.25;
+
+    // 畫 minor（若有）
+    if (minorMs != null) {
+      final startMinor = (viewMsStart ~/ minorMs) * minorMs;
+      for (int t = startMinor; t <= viewMsEnd; t += minorMs) {
+        // 避免畫到 major 的位置（讓 major 蓋上去）
+        if (t % majorMs == 0) continue;
+        final x = t * pxPerMs;
+        if (x < leftPx - 2 || x > leftPx + viewportWidthPx + 2) continue;
+        c.drawLine(Offset(x, 0), Offset(x, s.height), pMinor);
+      }
     }
-    for (double x = 0; x < s.width; x += 1000 * pxPerMs) {
+
+    // 畫 major
+    final startMajor = (viewMsStart ~/ majorMs) * majorMs;
+    for (int t = startMajor; t <= viewMsEnd; t += majorMs) {
+      final x = t * pxPerMs;
+      if (x < leftPx - 2 || x > leftPx + viewportWidthPx + 2) continue;
       c.drawLine(Offset(x, 0), Offset(x, s.height), pMajor);
     }
   }
 
   @override
-  bool shouldRepaint(covariant _GridPainter old) => old.pxPerMs != pxPerMs;
+  bool shouldRepaint(covariant _GridPainterWindow old) =>
+      old.pxPerMs != pxPerMs ||
+      old.viewportWidthPx != viewportWidthPx ||
+      old.scrollLeftPx != scrollLeftPx;
 }
 
 class _WaveformPainter extends CustomPainter {
@@ -688,4 +800,90 @@ class _WaveformPainter extends CustomPainter {
       old.peaks != peaks ||
       old.stepSamples != stepSamples ||
       old.pxPerMs != pxPerMs;
+}
+
+class _WaveformWindowPainter extends CustomPainter {
+  final EnvelopeLevel? env; // min/max 封包
+  final List<int> fallbackPeaks; // 舊峰值
+  final int fallbackStepSamples;
+  final double pxPerMs;
+
+  // ★ 新增：由畫家直接讀目前滾動位移與視窗寬（像素）
+  final ValueListenable<double> scrollLeftPx;
+  final double viewportWidthPx;
+
+  _WaveformWindowPainter({
+    required this.env,
+    required this.fallbackPeaks,
+    required this.fallbackStepSamples,
+    required this.pxPerMs,
+    required this.scrollLeftPx, // <—
+    required this.viewportWidthPx, // <—
+  }) : super(repaint: scrollLeftPx); // ★ 關鍵：滾動就 repaint
+
+  @override
+  void paint(Canvas c, Size s) {
+    c.clipRect(Offset.zero & s);
+
+    // 由滾動位移推導目前的可視毫秒區間
+    final leftPx = scrollLeftPx.value;
+    final int viewMsStart = (leftPx / pxPerMs).floor();
+    final int viewMsEnd = viewMsStart + (viewportWidthPx / pxPerMs).ceil();
+
+    final midY = s.height / 2;
+    final ampY = (s.height * 0.44);
+
+    if (env != null && env!.length > 0) {
+      final e = env!;
+      final i0 = e.indexFromMs(viewMsStart);
+      final i1 = e.indexFromMs(viewMsEnd);
+      final paint = Paint()
+        ..strokeWidth = 1.0
+        ..color = const Color(0xFF94A3B8);
+
+      for (int i = i0; i <= i1 && i < e.length; i++) {
+        final x = e.msAt(i) * pxPerMs; // 絕對座標（不要扣 viewMsStart）
+        if (x < leftPx - 2 || x > leftPx + viewportWidthPx + 2) continue; // 小快篩
+        final vMin = (e.minVals[i] / 32768.0).clamp(-1.0, 1.0);
+        final vMax = (e.maxVals[i] / 32768.0).clamp(-1.0, 1.0);
+        final y1 = midY - vMax * ampY;
+        final y2 = midY - vMin * ampY;
+        c.drawLine(Offset(x, y1), Offset(x, y2), paint);
+      }
+      return;
+    }
+
+    // 回退：舊 peaks
+    final step = math.max(1, fallbackStepSamples);
+    const sr = 48000;
+    int indexFromMs(int ms) => (((ms * sr) ~/ 1000) ~/ step).clamp(
+      0,
+      math.max(0, fallbackPeaks.length - 1),
+    );
+    int msAt(int idx) => ((idx * step) * 1000) ~/ sr;
+
+    final i0 = indexFromMs(viewMsStart);
+    final i1 = indexFromMs(viewMsEnd);
+    final paint = Paint()
+      ..strokeWidth = 1.0
+      ..color = const Color(0xFF8B9CB8);
+
+    for (int i = i0; i <= i1 && i < fallbackPeaks.length; i++) {
+      final x = msAt(i) * pxPerMs; // 絕對座標
+      if (x < leftPx - 2 || x > leftPx + viewportWidthPx + 2) continue;
+      final p = (fallbackPeaks[i] / 32768.0).clamp(0.0, 1.0);
+      final y1 = midY - p * ampY;
+      final y2 = midY + p * ampY;
+      c.drawLine(Offset(x, y1), Offset(x, y2), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _WaveformWindowPainter old) =>
+      old.env != env ||
+      old.fallbackPeaks != fallbackPeaks ||
+      old.fallbackStepSamples != fallbackStepSamples ||
+      old.pxPerMs != pxPerMs ||
+      old.viewportWidthPx != viewportWidthPx ||
+      old.scrollLeftPx != scrollLeftPx; // repaint 已處理滾動值
 }

--- a/lib/modules/services/singleTrackService.dart
+++ b/lib/modules/services/singleTrackService.dart
@@ -18,6 +18,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
+import 'package:clipnote_audio/modules/waveform/envelope.dart';
 import 'package:flutter/foundation.dart';
 import 'dart:ui' show Color;
 
@@ -117,6 +118,20 @@ class SingleTrack with ChangeNotifier {
   // 渲染後 PCM（mono s16le）
   Int16List _rendered = Int16List(0);
   Int16List get renderedPcm => _rendered;
+
+  // 多層封包（min/max）快取：key = stepSamples
+  final Map<int, EnvelopeLevel> envelopes = {};
+  // 推薦步階（以 samples 為單位；可依需求調整）
+  static const List<int> envelopeSteps = [
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+  ];
 
   // 建構子：給預設名稱與依 id 穩定取色
   SingleTrack(this.id)
@@ -449,6 +464,10 @@ class SingleTrackService {
     }
 
     track._rendered = out;
+    track.downsampledPcmPeak = const []; // 舊峰值可清空或保留
+    track.downsampleStep = kDefaultDownsampleStep;
+    track.envelopes.clear(); // ★ 失效舊封包
+
     track.isDirty.value = false;
     _markChanged();
   }
@@ -656,5 +675,77 @@ class SingleTrackService {
     final seg = segmentAtMs(ms);
     if (seg == null) return null;
     return splitSegment(seg, ms, clearFadesAtCut: clearFadesAtCut);
+  }
+
+  // 依 pxPerMs 選一層最接近「1px 寬」的封包（stepMs * pxPerMs ≈ 1）
+  EnvelopeLevel? pickEnvelopeForPxPerMs(double pxPerMs) {
+    final sr = 48000; // 你專案內部統一 48k
+    if (track.envelopes.isEmpty) return null;
+    EnvelopeLevel? best;
+    double bestDiff = 1e9;
+    for (final e in track.envelopes.values) {
+      final px = e.stepMs * pxPerMs;
+      final d = (px - 1.0).abs();
+      if (d < bestDiff) {
+        bestDiff = d;
+        best = e;
+      }
+    }
+    return best;
+  }
+
+  // 確保指定 stepSamples 的封包存在；沒有就建（Isolate）
+  Future<void> ensureEnvelopeLevel(int stepSamples) async {
+    if (track.envelopes.containsKey(stepSamples)) return;
+    final pcm = track.renderedPcm;
+    if (pcm.isEmpty) {
+      track.envelopes[stepSamples] = EnvelopeLevel(
+        sampleRate: 48000,
+        stepSamples: 1,
+        minVals: Int16List(0),
+        maxVals: Int16List(0),
+      );
+      _markChanged();
+      return;
+    }
+    final env = await buildEnvelopeLevelIsolate(
+      pcm: pcm,
+      sampleRate: 48000,
+      stepSamples: stepSamples,
+    );
+    track.envelopes[stepSamples] = env;
+    _markChanged();
+  }
+
+  // 預熱幾個常用層
+  Future<void> prewarmEnvelopes() async {
+    for (final s in SingleTrack.envelopeSteps) {
+      // 依序建，避免同時太多 Isolate（你也可併發 2~3 個）
+      await ensureEnvelopeLevel(s);
+    }
+  }
+
+  // 當渲染後 PCM 改變時，清空舊封包
+  void _invalidateEnvelopes() {
+    track.envelopes.clear();
+  }
+
+  // 根據當前縮放預先建一層（避免首次放大時卡頓）
+  Future<void> ensureEnvelopeForPxPerMs(double pxPerMs) async {
+    // 算出目標 stepSamples
+    final sr = 48000;
+    // 讓 stepMs ≈ 1/pxPerMs（每 1px 一個 bucket）
+    final targetStepMs = (1.0 / pxPerMs).clamp(1.0, 5000.0); // 1ms ~ 5s
+    int best = SingleTrack.envelopeSteps.first;
+    double bestDiff = 1e9;
+    for (final s in SingleTrack.envelopeSteps) {
+      final stepMs = (s * 1000.0) / sr;
+      final d = (stepMs - targetStepMs).abs();
+      if (d < bestDiff) {
+        bestDiff = d;
+        best = s;
+      }
+    }
+    await ensureEnvelopeLevel(best);
   }
 }

--- a/lib/modules/services/track_lane_service.dart
+++ b/lib/modules/services/track_lane_service.dart
@@ -21,7 +21,7 @@ class TrackLaneService {
 
   bool isLaneSelected(String laneId) => selectedLaneId.value == laneId;
   bool isSegmentSelected(String segId) => selectedSegmentId.value == segId;
-
+  final ValueNotifier<double> _scrollLeftPx = ValueNotifier(0);
   void selectLane(String laneId) {
     if (selectedLaneId.value != laneId) {
       selectedLaneId.value = laneId;

--- a/lib/modules/waveform/envelope.dart
+++ b/lib/modules/waveform/envelope.dart
@@ -1,0 +1,83 @@
+// lib/modules/waveform/envelope.dart
+import 'dart:isolate';
+import 'dart:typed_data';
+import 'dart:math' as math;
+
+class EnvelopeLevel {
+  final int sampleRate; // 48000
+  final int stepSamples; // 32/64/128/... 對應一個 bucket 有多少 samples
+  final Int16List minVals; // 每 bucket 的最小值（-32768..32767）
+  final Int16List maxVals; // 每 bucket 的最大值（-32768..32767）
+
+  const EnvelopeLevel({
+    required this.sampleRate,
+    required this.stepSamples,
+    required this.minVals,
+    required this.maxVals,
+  });
+
+  int get length => minVals.length;
+  int get stepMs => (stepSamples * 1000) ~/ sampleRate;
+  int indexFromMs(int ms) {
+    final idx = ((ms * sampleRate ~/ 1000) ~/ stepSamples);
+    return idx.clamp(0, math.max(0, length - 1));
+  }
+
+  int msAt(int idx) => ((idx * stepSamples) * 1000) ~/ sampleRate;
+}
+
+// ===== Isolate builder =====
+
+class _EnvJob {
+  final SendPort reply;
+  final Int16List pcm;
+  final int sampleRate;
+  final int stepSamples;
+  _EnvJob(this.reply, this.pcm, this.sampleRate, this.stepSamples);
+}
+
+void _envWorker(_EnvJob job) {
+  final pcm = job.pcm;
+  final step = math.max(1, job.stepSamples);
+  final n = (pcm.length + step - 1) ~/ step;
+
+  final minVals = Int16List(n);
+  final maxVals = Int16List(n);
+
+  for (int i = 0; i < n; i++) {
+    final start = i * step;
+    final end = math.min(start + step, pcm.length);
+    int mn = 32767;
+    int mx = -32768;
+    for (int j = start; j < end; j++) {
+      final v = pcm[j];
+      if (v < mn) mn = v;
+      if (v > mx) mx = v;
+    }
+    minVals[i] = mn;
+    maxVals[i] = mx;
+  }
+
+  job.reply.send(
+    EnvelopeLevel(
+      sampleRate: job.sampleRate,
+      stepSamples: step,
+      minVals: minVals,
+      maxVals: maxVals,
+    ),
+  );
+}
+
+Future<EnvelopeLevel> buildEnvelopeLevelIsolate({
+  required Int16List pcm,
+  required int sampleRate,
+  required int stepSamples,
+}) async {
+  final rp = ReceivePort();
+  await Isolate.spawn<_EnvJob>(
+    _envWorker,
+    _EnvJob(rp.sendPort, pcm, sampleRate, stepSamples),
+    errorsAreFatal: true,
+  );
+  return await rp.first as EnvelopeLevel;
+}


### PR DESCRIPTION
- Waveform（只畫可視區間）
  - 新增 _WaveformWindowPainter：改以內容座標 x = ms * pxPerMs，僅迭代可視索引(i0..i1)。
  - 以 ScrollController->ValueNotifier<double>(_scrollLeftPx) 驅動 repaint（super(repaint: …)）， 滑動即時重繪，不再需要點擊觸發。
  - 修正「右滑看不到波形」：移除座標系二次扣除 scrollOffset 的錯誤。
  - build() 中移除手算 viewMsStart/End，改由畫家依滾動值推導可視範圍。
  - 呼叫 ensureEnvelopeForPxPerMs(pxPerMs) 預熱最合適封包層，避免首次縮放卡頓。

- Grid（只畫可視區間 + 動態刻度）
  - 新增 _GridPainterWindow：依 pxPerMs/viewportWidth 自動挑選 major/minor 刻度（目標~120px/major， minor 至少 18px），10m 視野下不再過密。
  - 僅繪製可視範圍，並隨 _scrollLeftPx 變化即時 repaint。

- Envelope(min/max) 封包快取
  - 封包快取改為 per-track：SingleTrack 新增 `final Map<int, EnvelopeLevel> envelopes` 與 `static const envelopeSteps`，移除 SingleTrackService 內的重覆欄位。
  - rebuildRenderedNow() 後清空 `track.envelopes` 以失效舊封包；fallback 使用舊 peaks。
  - 修正 const 問題：移除 `const EnvelopeLevel(...)`；新增 `EnvelopeLevel.empty()` 工廠以建立空封包。

- 其他
  - 保留縮放對準播放頭的捲動邏輯與拖曳期間鎖水平滾動的手勢行為。

Files:
- lib/modules/waveform/envelope.dart (add: EnvelopeLevel + empty())
- lib/modules/services/singleTrackService.dart (move envelopes 至 SingleTrack；ensure/pick/prewarm；invalidate on rebuild)
- lib/modules/UI/ui2/ui2_track_lane.dart (add _scrollLeftPx；_WaveformWindowPainter；_GridPainterWindow；替換舊畫家)

Test:
- 載入 10–30 分鐘音檔：快速橫向滑動波形連續顯示，無需點擊觸發。
- 縮放：視窗保持播放頭相對位置；封包層依縮放切換、無明顯 jank。
- 10m 視野：major/minor 線條稀疏清晰（約 30–120s major，10–15s minor，視縮放而定）。